### PR TITLE
Make webclient call name_get()

### DIFF
--- a/l10n_fr_naf_ape/partner_view.xml
+++ b/l10n_fr_naf_ape/partner_view.xml
@@ -7,9 +7,10 @@
             <field name="model">res.partner</field>
             <field name="inherit_id" ref="base.view_partner_form" />
             <field name="arch" type="xml">
-                <field name="title" position="after">
+                <field name="website" position="after">
                     <field name="ape_id" context="{'partner_category_display': 'short'}"
-                           domain="[('parent_id', 'child_of', %(l10n_eu_nace.nace_root)d)]"/>
+                        attrs="{'invisible': [('is_company', '=', False)]}"
+                        domain="[('parent_id', 'child_of', %(l10n_eu_nace.nace_root)d)]" />
                 </field>
             </field>
         </record>

--- a/l10n_fr_naf_ape/partner_view.xml
+++ b/l10n_fr_naf_ape/partner_view.xml
@@ -10,7 +10,8 @@
                 <field name="website" position="after">
                     <field name="ape_id" context="{'partner_category_display': 'short'}"
                         attrs="{'invisible': [('is_company', '=', False)]}"
-                        domain="[('parent_id', 'child_of', %(l10n_eu_nace.nace_root)d)]" />
+                        domain="[('parent_id', 'child_of', %(l10n_eu_nace.nace_root)d)]"
+                        options='{"always_reload": True}'/>
                 </field>
             </field>
         </record>


### PR DESCRIPTION
This proposal fixes a glitch related to the web client in v7 and brings a few cosmetic changes to l10n_fr_naf_ape.
This change displays the short name of the NAF category on the partner form.
To do this, it forces the web client to call name_get() when it displays the NAF field on the partner form instead of relying on a context-insensitive prefetch.
Ported from original merge proposal on launchpad https://code.launchpad.net/~numerigraphe-team/openerp-data/7.0-fix-naf-shortname/+merge/215446
