### PR TITLE
Add code3166 3-char codes to res_country

### DIFF
--- a/code3166/README.rst
+++ b/code3166/README.rst
@@ -1,0 +1,47 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+==========
+ISO 3166-1
+==========
+
+This module adds ISO 3166-1 alpha-3 (3-char) codes to countries, so that other
+modules can use them.
+
+Check https://en.wikipedia.org/wiki/ISO_3166-1 for ISO 3166-1 info.
+
+
+Known issues / Roadmap
+======================
+
+* No alpha-2 (2-char) and numeric codes provided.
+
+Credits
+=======
+
+Contributors
+------------
+
+* ASR-OSS (http://www.asr-oss.com)
+* FactorLibre (http://www.factorlibre.com)
+* Tecon (http://www.tecon.es)
+* Pexego (http://www.pexego.es)
+* Malagatic (http://www.malagatic.es)
+* Comunitea (http://www.comunitea.com)
+* Binovo IT Human Project (http://www.binovo.es)
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/code3166/__init__.py
+++ b/code3166/__init__.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    Copyright (c) 2009 Alejandro Sanchez (http://www.asr-oss.com)
+#                       Alejandro Sanchez <alejandro@asr-oss.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import models
+
+def pre_init_hook(cr):
+    cr.execute("update ir_model_data set noupdate=false where "
+               "module = 'base' and model = 'res.country'")
+
+
+def post_init_hook(cr, registry):
+    cr.execute("update ir_model_data set noupdate=true where "
+               "module = 'base' and model = 'res.country'")

--- a/code3166/__openerp__.py
+++ b/code3166/__openerp__.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    Copyright (c) 2009 Alejandro Sanchez (http://www.asr-oss.com)
+#                       Alejandro Sanchez <alejandro@asr-oss.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the Affero GNU General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the Affero GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    "name": "ISO 3166-1 codes for countries",
+    "version": "8.0.1.0.0",
+    "author": "ASR-OSS, "
+              "FactorLibre, "
+              "Tecon, "
+              "Pexego, "
+              "Malagatic, "
+              "Comunitea, "
+              "Binovo IT Human Project"
+              "Odoo Community Association (OCA)",
+    "category": "",
+    "website": "",
+    "license": "AGPL-3",
+    "depends": ["base"],
+    "data": [
+        "views/country_view.xml",
+        "data/data_res_country.xml",
+    ],
+    "pre_init_hook": "pre_init_hook",
+    "post_init_hook": "post_init_hook",
+    "installable": True,
+}

--- a/code3166/data/data_res_country.xml
+++ b/code3166/data/data_res_country.xml
@@ -1,0 +1,728 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data noupdate='0'>
+        <record id="base.ad" model="res.country">
+            <field name="code_3166">AND</field>
+        </record>
+        <record id="base.ae" model="res.country">
+            <field name="code_3166">ARE</field>
+        </record>
+        <record id="base.af" model="res.country">
+            <field name="code_3166">AFG</field>
+        </record>
+        <record id="base.ag" model="res.country">
+            <field name="code_3166">ATG</field>
+        </record>
+        <record id="base.ai" model="res.country">
+            <field name="code_3166">AIA</field>
+        </record>
+        <record id="base.al" model="res.country">
+            <field name="code_3166">ALB</field>
+        </record>
+        <record id="base.am" model="res.country">
+            <field name="code_3166">ARM</field>
+        </record>
+        <record id="base.an" model="res.country">
+            <field name="code_3166">ANT</field>
+        </record>
+        <record id="base.ao" model="res.country">
+            <field name="code_3166">AGO</field>
+        </record>
+        <record id="base.aq" model="res.country">
+            <field name="code_3166">ATA</field>
+        </record>
+        <record id="base.ar" model="res.country">
+            <field name="code_3166">ARG</field>
+        </record>
+        <record id="base.as" model="res.country">
+            <field name="code_3166">ASM</field>
+        </record>
+        <record id="base.at" model="res.country">
+            <field name="code_3166">AUT</field>
+        </record>
+        <record id="base.au" model="res.country">
+            <field name="code_3166">AUS</field>
+        </record>
+        <record id="base.aw" model="res.country">
+            <field name="code_3166">ABW</field>
+        </record>
+        <record id="base.az" model="res.country">
+            <field name="code_3166">AZE</field>
+        </record>
+        <record id="base.ba" model="res.country">
+            <field name="code_3166">BIH</field>
+        </record>
+        <record id="base.bb" model="res.country">
+            <field name="code_3166">BRB</field>
+        </record>
+        <record id="base.bd" model="res.country">
+            <field name="code_3166">BGD</field>
+        </record>
+        <record id="base.be" model="res.country">
+            <field name="code_3166">BEL</field>
+        </record>
+        <record id="base.bf" model="res.country">
+            <field name="code_3166">BFA</field>
+        </record>
+        <record id="base.bg" model="res.country">
+            <field name="code_3166">BGR</field>
+        </record>
+        <record id="base.bh" model="res.country">
+            <field name="code_3166">BHR</field>
+        </record>
+        <record id="base.bi" model="res.country">
+            <field name="code_3166">BDI</field>
+        </record>
+        <record id="base.bj" model="res.country">
+            <field name="code_3166">BEN</field>
+        </record>
+        <record id="base.bm" model="res.country">
+            <field name="code_3166">BMU</field>
+        </record>
+        <record id="base.bn" model="res.country">
+            <field name="code_3166">BRN</field>
+        </record>
+        <record id="base.bo" model="res.country">
+            <field name="code_3166">BOL</field>
+        </record>
+        <record id="base.br" model="res.country">
+            <field name="code_3166">ASM</field>
+        </record>
+        <record id="base.bs" model="res.country">
+            <field name="code_3166">BRA</field>
+        </record>
+        <record id="base.bt" model="res.country">
+            <field name="code_3166">BTN</field>
+        </record>
+        <record id="base.bv" model="res.country">
+            <field name="code_3166">BVT</field>
+        </record>
+        <record id="base.bw" model="res.country">
+            <field name="code_3166">BWA</field>
+        </record>
+        <record id="base.by" model="res.country">
+            <field name="code_3166">BLR</field>
+        </record>
+        <record id="base.bz" model="res.country">
+            <field name="code_3166">BLZ</field>
+        </record>
+        <record id="base.ca" model="res.country">
+            <field name="code_3166">CAN</field>
+        </record>
+        <record id="base.cc" model="res.country">
+            <field name="code_3166">CCK</field>
+        </record>
+        <record id="base.cf" model="res.country">
+            <field name="code_3166">CAF</field>
+        </record>
+        <record id="base.cd" model="res.country">
+            <field name="code_3166">COD</field>
+        </record>
+        <record id="base.cg" model="res.country">
+            <field name="code_3166">COG</field>
+        </record>
+        <record id="base.ch" model="res.country">
+            <field name="code_3166">CHE</field>
+        </record>
+        <record id="base.ci" model="res.country">
+            <field name="code_3166">CIV</field>
+        </record>
+        <record id="base.ck" model="res.country">
+            <field name="code_3166">COK</field>
+        </record>
+        <record id="base.cl" model="res.country">
+            <field name="code_3166">CHL</field>
+        </record>
+        <record id="base.cm" model="res.country">
+            <field name="code_3166">CMR</field>
+        </record>
+        <record id="base.cn" model="res.country">
+            <field name="code_3166">CHN</field>
+        </record>
+        <record id="base.co" model="res.country">
+            <field name="code_3166">COL</field>
+        </record>
+        <record id="base.cr" model="res.country">
+            <field name="code_3166">CRI</field>
+        </record>
+        <record id="base.rs" model="res.country">
+            <field name="code_3166">SRB</field>
+        </record>
+        <record id="base.me" model="res.country">
+            <field name="code_3166">MNE</field>
+        </record>
+        <record id="base.cu" model="res.country">
+            <field name="code_3166">CUB</field>
+        </record>
+        <record id="base.cv" model="res.country">
+            <field name="code_3166">CPV</field>
+        </record>
+        <record id="base.cx" model="res.country">
+            <field name="code_3166">CXR</field>
+        </record>
+        <record id="base.cy" model="res.country">
+            <field name="code_3166">CYP</field>
+        </record>
+        <record id="base.cz" model="res.country">
+            <field name="code_3166">CZE</field>
+        </record>
+        <record id="base.de" model="res.country">
+            <field name="code_3166">DEU</field>
+        </record>
+        <record id="base.dj" model="res.country">
+            <field name="code_3166">DJI</field>
+        </record>
+        <record id="base.dk" model="res.country">
+            <field name="code_3166">DNK</field>
+        </record>
+        <record id="base.dm" model="res.country">
+            <field name="code_3166">DMA</field>
+        </record>
+        <record id="base.do" model="res.country">
+            <field name="code_3166">DOM</field>
+        </record>
+        <record id="base.dz" model="res.country">
+            <field name="code_3166">DZA</field>
+        </record>
+        <record id="base.ec" model="res.country">
+            <field name="code_3166">ECU</field>
+        </record>
+        <record id="base.ee" model="res.country">
+            <field name="code_3166">EST</field>
+        </record>
+        <record id="base.eg" model="res.country">
+            <field name="code_3166">EGY</field>
+        </record>
+        <record id="base.eh" model="res.country">
+            <field name="code_3166">ESH</field>
+        </record>
+        <record id="base.er" model="res.country">
+            <field name="code_3166">ERI</field>
+        </record>
+        <record id="base.es" model="res.country">
+            <field name="code_3166">ESP</field>
+        </record>
+        <record id="base.et" model="res.country">
+            <field name="code_3166">ETH</field>
+        </record>
+        <record id="base.fi" model="res.country">
+            <field name="code_3166">FIN</field>
+        </record>
+        <record id="base.fj" model="res.country">
+            <field name="code_3166">FJI</field>
+        </record>
+        <record id="base.fk" model="res.country">
+            <field name="code_3166">FLK</field>
+        </record>
+        <record id="base.fm" model="res.country">
+            <field name="code_3166">FSM</field>
+        </record>
+        <record id="base.fo" model="res.country">
+            <field name="code_3166">FRO</field>
+        </record>
+        <record id="base.fr" model="res.country">
+            <field name="code_3166">FRA</field>
+        </record>
+        <record id="base.ga" model="res.country">
+            <field name="code_3166">GAB</field>
+        </record>
+        <record id="base.gd" model="res.country">
+            <field name="code_3166">GRD</field>
+        </record>
+        <record id="base.ge" model="res.country">
+            <field name="code_3166">GEO</field>
+        </record>
+        <record id="base.gf" model="res.country">
+            <field name="code_3166">GUF</field>
+        </record>
+        <record id="base.gh" model="res.country">
+            <field name="code_3166">GHA</field>
+        </record>
+        <record id="base.gi" model="res.country">
+            <field name="code_3166">GIB</field>
+        </record>
+        <record id="base.gl" model="res.country">
+            <field name="code_3166">GRL</field>
+        </record>
+        <record id="base.gm" model="res.country">
+            <field name="code_3166">GMB</field>
+        </record>
+        <record id="base.gn" model="res.country">
+            <field name="code_3166">GIN</field>
+        </record>
+        <record id="base.gp" model="res.country">
+            <field name="code_3166">GLP</field>
+        </record>
+        <record id="base.gq" model="res.country">
+            <field name="code_3166">GNQ</field>
+        </record>
+        <record id="base.gr" model="res.country">
+            <field name="code_3166">GRC</field>
+        </record>
+        <record id="base.gs" model="res.country">
+            <field name="code_3166">SGS</field>
+        </record>
+        <record id="base.gt" model="res.country">
+            <field name="code_3166">GTM</field>
+        </record>
+        <record id="base.gu" model="res.country">
+            <field name="code_3166">GUM</field>
+        </record>
+        <record id="base.gw" model="res.country">
+            <field name="code_3166">GNB</field>
+        </record>
+        <record id="base.gy" model="res.country">
+            <field name="code_3166">GUY</field>
+        </record>
+        <record id="base.hk" model="res.country">
+            <field name="code_3166">HKG</field>
+        </record>
+        <record id="base.hm" model="res.country">
+            <field name="code_3166">HMD</field>
+        </record>
+        <record id="base.hn" model="res.country">
+            <field name="code_3166">HND</field>
+        </record>
+        <record id="base.hr" model="res.country">
+            <field name="code_3166">HRV</field>
+        </record>
+        <record id="base.ht" model="res.country">
+            <field name="code_3166">HTI</field>
+        </record>
+        <record id="base.hu" model="res.country">
+            <field name="code_3166">HUN</field>
+        </record>
+        <record id="base.id" model="res.country">
+            <field name="code_3166">IDN</field>
+        </record>
+        <record id="base.ie" model="res.country">
+            <field name="code_3166">IRL</field>
+        </record>
+        <record id="base.il" model="res.country">
+            <field name="code_3166">ISR</field>
+        </record>
+        <record id="base.in" model="res.country">
+            <field name="code_3166">IND</field>
+        </record>
+        <record id="base.io" model="res.country">
+            <field name="code_3166">IOT</field>
+        </record>
+        <record id="base.iq" model="res.country">
+            <field name="code_3166">IRQ</field>
+        </record>
+        <record id="base.ir" model="res.country">
+            <field name="code_3166">IRN</field>
+        </record>
+        <record id="base.is" model="res.country">
+            <field name="code_3166">ISL</field>
+        </record>
+        <record id="base.it" model="res.country">
+            <field name="code_3166">ITA</field>
+        </record>
+        <record id="base.jm" model="res.country">
+            <field name="code_3166">JAM</field>
+        </record>
+        <record id="base.jo" model="res.country">
+            <field name="code_3166">JOR</field>
+        </record>
+        <record id="base.jp" model="res.country">
+            <field name="code_3166">JPN</field>
+        </record>
+        <record id="base.ke" model="res.country">
+            <field name="code_3166">KEN</field>
+        </record>
+        <record id="base.kg" model="res.country">
+            <field name="code_3166">KGZ</field>
+        </record>
+        <record id="base.kh" model="res.country">
+            <field name="code_3166">KHM</field>
+        </record>
+        <record id="base.ki" model="res.country">
+            <field name="code_3166">KIR</field>
+        </record>
+        <record id="base.km" model="res.country">
+            <field name="code_3166">COM</field>
+        </record>
+        <record id="base.kn" model="res.country">
+            <field name="code_3166">KNA</field>
+        </record>
+        <record id="base.kp" model="res.country">
+            <field name="code_3166">PRK</field>
+        </record>
+        <record id="base.kr" model="res.country">
+            <field name="code_3166">KOR</field>
+        </record>
+        <record id="base.kw" model="res.country">
+            <field name="code_3166">KWT</field>
+        </record>
+        <record id="base.ky" model="res.country">
+            <field name="code_3166">CYM</field>
+        </record>
+        <record id="base.kz" model="res.country">
+            <field name="code_3166">KAZ</field>
+        </record>
+        <record id="base.la" model="res.country">
+            <field name="code_3166">LAO</field>
+        </record>
+        <record id="base.lb" model="res.country">
+            <field name="code_3166">LBN</field>
+        </record>
+        <record id="base.lc" model="res.country">
+            <field name="code_3166">LCA</field>
+        </record>
+        <record id="base.li" model="res.country">
+            <field name="code_3166">LIE</field>
+        </record>
+        <record id="base.lk" model="res.country">
+            <field name="code_3166">LKA</field>
+        </record>
+        <record id="base.lr" model="res.country">
+            <field name="code_3166">LBR</field>
+        </record>
+        <record id="base.ls" model="res.country">
+            <field name="code_3166">LSO</field>
+        </record>
+        <record id="base.lt" model="res.country">
+            <field name="code_3166">LTU</field>
+        </record>
+        <record id="base.lu" model="res.country">
+            <field name="code_3166">LUX</field>
+        </record>
+        <record id="base.lv" model="res.country">
+            <field name="code_3166">LVA</field>
+        </record>
+        <record id="base.ly" model="res.country">
+            <field name="code_3166">LBY</field>
+        </record>
+        <record id="base.ma" model="res.country">
+            <field name="code_3166">MAR</field>
+        </record>
+        <record id="base.mc" model="res.country">
+            <field name="code_3166">MCO</field>
+        </record>
+        <record id="base.md" model="res.country">
+            <field name="code_3166">MDA</field>
+        </record>
+        <record id="base.mg" model="res.country">
+            <field name="code_3166">MDG</field>
+        </record>
+        <record id="base.mh" model="res.country">
+            <field name="code_3166">MHL</field>
+        </record>
+        <record id="base.mk" model="res.country">
+            <field name="code_3166">MKD</field>
+        </record>
+        <record id="base.ml" model="res.country">
+            <field name="code_3166">MLI</field>
+        </record>
+        <record id="base.mm" model="res.country">
+            <field name="code_3166">MMR</field>
+        </record>
+        <record id="base.mn" model="res.country">
+            <field name="code_3166">MNG</field>
+        </record>
+        <record id="base.mo" model="res.country">
+            <field name="code_3166">MAC</field>
+        </record>
+        <record id="base.mp" model="res.country">
+            <field name="code_3166">MNP</field>
+        </record>
+        <record id="base.mq" model="res.country">
+            <field name="code_3166">MTQ</field>
+        </record>
+        <record id="base.mr" model="res.country">
+            <field name="code_3166">MRT</field>
+        </record>
+        <record id="base.ms" model="res.country">
+            <field name="code_3166">MSR</field>
+        </record>
+        <record id="base.mt" model="res.country">
+            <field name="code_3166">MLT</field>
+        </record>
+        <record id="base.mu" model="res.country">
+            <field name="code_3166">MUS</field>
+        </record>
+        <record id="base.mv" model="res.country">
+            <field name="code_3166">MDV</field>
+        </record>
+        <record id="base.mw" model="res.country">
+            <field name="code_3166">MWI</field>
+        </record>
+        <record id="base.mx" model="res.country">
+            <field name="code_3166">MEX</field>
+        </record>
+        <record id="base.my" model="res.country">
+            <field name="code_3166">MYS</field>
+        </record>
+        <record id="base.mz" model="res.country">
+            <field name="code_3166">MOZ</field>
+        </record>
+        <record id="base.na" model="res.country">
+            <field name="code_3166">NAM</field>
+        </record>
+        <record id="base.nc" model="res.country">
+            <field name="code_3166">NCL</field>
+        </record>
+        <record id="base.ne" model="res.country">
+            <field name="code_3166">NER</field>
+        </record>
+        <record id="base.nf" model="res.country">
+            <field name="code_3166">NFK</field>
+        </record>
+        <record id="base.ng" model="res.country">
+            <field name="code_3166">NGA</field>
+        </record>
+        <record id="base.ni" model="res.country">
+            <field name="code_3166">NIC</field>
+        </record>
+        <record id="base.nl" model="res.country">
+            <field name="code_3166">NLD</field>
+        </record>
+        <record id="base.no" model="res.country">
+            <field name="code_3166">NOR</field>
+        </record>
+        <record id="base.np" model="res.country">
+            <field name="code_3166">NPL</field>
+        </record>
+        <record id="base.nr" model="res.country">
+            <field name="code_3166">NRU</field>
+        </record>
+        <record id="base.nu" model="res.country">
+            <field name="code_3166">NIU</field>
+        </record>
+        <record id="base.nz" model="res.country">
+            <field name="code_3166">NZL</field>
+        </record>
+        <record id="base.om" model="res.country">
+            <field name="code_3166">OMN</field>
+        </record>
+        <record id="base.pa" model="res.country">
+            <field name="code_3166">PAN</field>
+        </record>
+        <record id="base.pe" model="res.country">
+            <field name="code_3166">PER</field>
+        </record>
+        <record id="base.pf" model="res.country">
+            <field name="code_3166">PYF</field>
+        </record>
+        <record id="base.pg" model="res.country">
+            <field name="code_3166">PNG</field>
+        </record>
+        <record id="base.ph" model="res.country">
+            <field name="code_3166">PHL</field>
+        </record>
+        <record id="base.pk" model="res.country">
+            <field name="code_3166">PAK</field>
+        </record>
+        <record id="base.pl" model="res.country">
+            <field name="code_3166">POL</field>
+        </record>
+        <record id="base.pm" model="res.country">
+            <field name="code_3166">SPM</field>
+        </record>
+        <record id="base.pn" model="res.country">
+            <field name="code_3166">PCN</field>
+        </record>
+        <record id="base.pr" model="res.country">
+            <field name="code_3166">PRI</field>
+        </record>
+        <record id="base.pt" model="res.country">
+            <field name="code_3166">PRT</field>
+        </record>
+        <record id="base.pw" model="res.country">
+            <field name="code_3166">PLW</field>
+        </record>
+        <record id="base.py" model="res.country">
+            <field name="code_3166">PRY</field>
+        </record>
+        <record id="base.qa" model="res.country">
+            <field name="code_3166">QAT</field>
+        </record>
+        <record id="base.re" model="res.country">
+            <field name="code_3166">REU</field>
+        </record>
+        <record id="base.ro" model="res.country">
+            <field name="code_3166">ROU</field>
+        </record>
+        <record id="base.ru" model="res.country">
+            <field name="code_3166">RUS</field>
+        </record>
+        <record id="base.rw" model="res.country">
+            <field name="code_3166">RWA</field>
+        </record>
+        <record id="base.sa" model="res.country">
+            <field name="code_3166">SAU</field>
+        </record>
+        <record id="base.sb" model="res.country">
+            <field name="code_3166">SLB</field>
+        </record>
+        <record id="base.sc" model="res.country">
+            <field name="code_3166">SYC</field>
+        </record>
+        <record id="base.sd" model="res.country">
+            <field name="code_3166">SDN</field>
+        </record>
+        <record id="base.se" model="res.country">
+            <field name="code_3166">SWE</field>
+        </record>
+        <record id="base.sg" model="res.country">
+            <field name="code_3166">SGP</field>
+        </record>
+        <record id="base.sh" model="res.country">
+            <field name="code_3166">SHN</field>
+        </record>
+        <record id="base.si" model="res.country">
+            <field name="code_3166">SVN</field>
+        </record>
+        <record id="base.sj" model="res.country">
+            <field name="code_3166">SJM</field>
+        </record>
+        <record id="base.sk" model="res.country">
+            <field name="code_3166">SVK</field>
+        </record>
+        <record id="base.sl" model="res.country">
+            <field name="code_3166">SLE</field>
+        </record>
+        <record id="base.sm" model="res.country">
+            <field name="code_3166">SMR</field>
+        </record>
+        <record id="base.sn" model="res.country">
+            <field name="code_3166">SEN</field>
+        </record>
+        <record id="base.so" model="res.country">
+            <field name="code_3166">SOM</field>
+        </record>
+        <record id="base.sr" model="res.country">
+            <field name="code_3166">SUR</field>
+        </record>
+        <record id="base.st" model="res.country">
+            <field name="code_3166">STP</field>
+        </record>
+        <record id="base.sv" model="res.country">
+            <field name="code_3166">SLV</field>
+        </record>
+        <record id="base.sy" model="res.country">
+            <field name="code_3166">SYR</field>
+        </record>
+        <record id="base.sz" model="res.country">
+            <field name="code_3166">SWZ</field>
+        </record>
+        <record id="base.tc" model="res.country">
+            <field name="code_3166">TCA</field>
+        </record>
+        <record id="base.td" model="res.country">
+            <field name="code_3166">TCD</field>
+        </record>
+        <record id="base.tf" model="res.country">
+            <field name="code_3166">ATF</field>
+        </record>
+        <record id="base.tg" model="res.country">
+            <field name="code_3166">TGO</field>
+        </record>
+        <record id="base.th" model="res.country">
+            <field name="code_3166">THA</field>
+        </record>
+        <record id="base.tj" model="res.country">
+            <field name="code_3166">TJK</field>
+        </record>
+        <record id="base.tk" model="res.country">
+            <field name="code_3166">TKL</field>
+        </record>
+        <record id="base.tm" model="res.country">
+            <field name="code_3166">TKM</field>
+        </record>
+        <record id="base.tn" model="res.country">
+            <field name="code_3166">TUN</field>
+        </record>
+        <record id="base.to" model="res.country">
+            <field name="code_3166">TON</field>
+        </record>
+        <record id="base.tp" model="res.country">
+            <field name="code_3166">TLS</field>
+        </record>
+        <record id="base.tr" model="res.country">
+            <field name="code_3166">TUR</field>
+        </record>
+        <record id="base.tt" model="res.country">
+            <field name="code_3166">TTO</field>
+        </record>
+        <record id="base.tv" model="res.country">
+            <field name="code_3166">TUV</field>
+        </record>
+        <record id="base.tw" model="res.country">
+            <field name="code_3166">TWN</field>
+        </record>
+        <record id="base.tz" model="res.country">
+            <field name="code_3166">TZA</field>
+        </record>
+        <record id="base.ua" model="res.country">
+            <field name="code_3166">UKR</field>
+        </record>
+        <record id="base.ug" model="res.country">
+            <field name="code_3166">UGA</field>
+        </record>
+        <record id="base.uk" model="res.country">
+            <field name="code_3166">GBR</field>
+        </record>
+        <record id="base.um" model="res.country">
+            <field name="code_3166">UMI</field>
+        </record>
+        <record id="base.us" model="res.country">
+            <field name="code_3166">USA</field>
+        </record>
+        <record id="base.uy" model="res.country">
+            <field name="code_3166">URY</field>
+        </record>
+        <record id="base.uz" model="res.country">
+            <field name="code_3166">UZB</field>
+        </record>
+        <record id="base.va" model="res.country">
+            <field name="code_3166">VAT</field>
+        </record>
+        <record id="base.vc" model="res.country">
+            <field name="code_3166">VCT</field>
+        </record>
+        <record id="base.ve" model="res.country">
+            <field name="code_3166">VEN</field>
+        </record>
+        <record id="base.vg" model="res.country">
+            <field name="code_3166">VGB</field>
+        </record>
+        <record id="base.vi" model="res.country">
+            <field name="code_3166">VIR</field>
+        </record>
+        <record id="base.vn" model="res.country">
+            <field name="code_3166">VNM</field>
+        </record>
+        <record id="base.vu" model="res.country">
+            <field name="code_3166">VUT</field>
+        </record>
+        <record id="base.wf" model="res.country">
+            <field name="code_3166">WLF</field>
+        </record>
+        <record id="base.ws" model="res.country">
+            <field name="code_3166">WSM</field>
+        </record>
+        <record id="base.ye" model="res.country">
+            <field name="code_3166">YEM</field>
+        </record>
+        <record id="base.yt" model="res.country">
+            <field name="code_3166">MYT</field>
+        </record>
+        <record id="base.za" model="res.country">
+            <field name="code_3166">ZAF</field>
+        </record>
+        <record id="base.zm" model="res.country">
+            <field name="code_3166">ZMB</field>
+        </record>
+        <!-- DEPRECATED, News name of Zaire is Democratic Republic of the Congo ! -->
+        <record id="base.zr" model="res.country">
+            <field name="code_3166">ZAR</field>
+        </record>
+        <record id="base.zw" model="res.country">
+            <field name="code_3166">ZWE</field>
+        </record>
+
+    </data>
+</openerp>
+

--- a/code3166/models/__init__.py
+++ b/code3166/models/__init__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    Copyright (c) 2016 Eneko Lacunza (http://www.binovo.es)
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import country

--- a/code3166/models/country.py
+++ b/code3166/models/country.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    Copyright (c) 2009 Alejandro Sanchez (http://www.asr-oss.com)
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the Affero GNU General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the Affero GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import models, fields
+
+
+class Country(models.Model):
+
+    _inherit = 'res.country'
+
+    code_3166 = fields.Char('Code ISO 3166', size=3,
+                            help='ISO 3166 alfa-3 (3-char) code for the country')

--- a/code3166/views/country_view.xml
+++ b/code3166/views/country_view.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <!-- Country Expasion   -->
+        <record id="view_country_form_ext" model="ir.ui.view">
+            <field name="name">res.country.form_ext</field>
+            <field name="model">res.country</field>
+            <field name="inherit_id" ref="base.view_country_form"/>
+            <field name="type">form</field>
+            <field name="arch" type="xml">
+                <field name="code" position="after">
+                    <field name="code_3166"/>
+                </field>
+            </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
This is a initial PR to add 3-char codes to res_country, needed for electronic invoices in Spain.

I suspect existing 2-char codes in res_country are also ISO 3166-1, so maybe we should fix module and new field names. Also maybe iso3166_1 would be a better name than code3166?

@pedrobaeza feel free to suggest changes or to make them directly, I won't be able to look into this until tomorrow morning CET.

Thanks
