### PR TITLE
[10.0] Add field 'UNECE Due date' on taxes and corresponding nomenclature

### DIFF
--- a/account_payment_unece/__manifest__.py
+++ b/account_payment_unece/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     'name': 'Account Payment UNECE',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'category': 'Accounting & Finance',
     'license': 'AGPL-3',
     'summary': 'UNECE nomenclature for the payment methods',

--- a/account_payment_unece/data/unece.xml
+++ b/account_payment_unece/data/unece.xml
@@ -2,13 +2,13 @@
 <odoo noupdate="0">
 
 <!-- unece.code.list
-Source : http://www.unece.org/trade/untdid/d99b/tred/tred4461.htm  -->
+Source : https://www.unece.org/fileadmin/DAM/trade/untdid/d16b/tred/tred4461.htm  -->
 
 <record id="payment_means_1" model="unece.code.list">
     <field name="type">payment_means</field>
     <field name="code">1</field>
     <field name="name">Instrument not defined</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">Not defined legally enforceable agreement between two or more parties (expressing a contractual right or a right to the payment of money).</field>
 </record>
 
 <record id="payment_means_2" model="unece.code.list">
@@ -71,7 +71,7 @@ Source : http://www.unece.org/trade/untdid/d99b/tred/tred4461.htm  -->
     <field name="type">payment_means</field>
     <field name="code">10</field>
     <field name="name">In cash</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">Payment by currency (including bills and coins) in circulation, including checking account deposits.</field>
 </record>
 
 <record id="payment_means_11" model="unece.code.list">
@@ -106,14 +106,14 @@ Source : http://www.unece.org/trade/untdid/d99b/tred/tred4461.htm  -->
     <field name="type">payment_means</field>
     <field name="code">15</field>
     <field name="name">Bookentry credit</field>
-    <field name="description">A credit transaction, initiated from the buyer's account to the seller's account at the save financial institution.</field>
+    <field name="description">A credit entry between two accounts at the same bank branch. Synonym: house credit.</field>
 </record>
 
 <record id="payment_means_16" model="unece.code.list">
     <field name="type">payment_means</field>
     <field name="code">16</field>
     <field name="name">Bookentry debit</field>
-    <field name="description">A debit transaction initiated from the seller's account to the seller's account at the same financial institution.</field>
+    <field name="description">A debit entry between two accounts at the same bank branch. Synonym: house debit.</field>
 </record>
 
 <record id="payment_means_17" model="unece.code.list">
@@ -141,7 +141,7 @@ Source : http://www.unece.org/trade/untdid/d99b/tred/tred4461.htm  -->
     <field name="type">payment_means</field>
     <field name="code">20</field>
     <field name="name">Cheque</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">Payment by a pre-printed form on which instructions are given to an account holder (a bank or building society) to pay a stated sum to a named recipient.</field>
 </record>
 
 <record id="payment_means_21" model="unece.code.list">
@@ -155,21 +155,28 @@ Source : http://www.unece.org/trade/untdid/d99b/tred/tred4461.htm  -->
     <field name="type">payment_means</field>
     <field name="code">22</field>
     <field name="name">Certified banker's draft</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">Cheque drawn by a bank on itself or its agent. A person who owes money to another buys the draft from a bank for cash and hands it to the creditor who need have no fear that it might be dishonoured.</field>
 </record>
 
 <record id="payment_means_23" model="unece.code.list">
     <field name="type">payment_means</field>
     <field name="code">23</field>
     <field name="name">Bank cheque (issued by a banking or similar establishment)</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">Payment by a pre-printed form, which has been completed by a financial institution, on which instructions are given to an account holder (a bank or building society) to pay a stated sum to a named recipient.</field>
+</record>
+
+<record id="payment_means_24" model="unece.code.list">
+    <field name="type">payment_means</field>
+    <field name="code">24</field>
+    <field name="name">Bill of exchange awaiting acceptance</field>
+    <field name="description">Bill drawn by the creditor on the debtor but not yet accepted by the debtor.</field>
 </record>
 
 <record id="payment_means_25" model="unece.code.list">
     <field name="type">payment_means</field>
     <field name="code">25</field>
     <field name="name">Certified cheque</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">Payment by a pre-printed form stamped with the paying bank's certification on which instructions are given to an account holder (a bank or building society) to pay a stated sum to a named recipient.</field>
 </record>
 
 <record id="payment_means_26" model="unece.code.list">
@@ -204,14 +211,14 @@ Source : http://www.unece.org/trade/untdid/d99b/tred/tred4461.htm  -->
     <field name="type">payment_means</field>
     <field name="code">30</field>
     <field name="name">Credit transfer</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">Payment by credit movement of funds from one account to another.</field>
 </record>
 
 <record id="payment_means_31" model="unece.code.list">
     <field name="type">payment_means</field>
     <field name="code">31</field>
     <field name="name">Debit transfer</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">Payment by debit movement of funds from one account to another.</field>
 </record>
 
 <record id="payment_means_32" model="unece.code.list">
@@ -288,7 +295,7 @@ Source : http://www.unece.org/trade/untdid/d99b/tred/tred4461.htm  -->
     <field name="type">payment_means</field>
     <field name="code">42</field>
     <field name="name">Payment to bank account</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">Payment by an arrangement for settling debts that is operated by the Post Office.</field>
 </record>
 
 <record id="payment_means_43" model="unece.code.list">
@@ -333,10 +340,6 @@ Source : http://www.unece.org/trade/untdid/d99b/tred/tred4461.htm  -->
     <field name="description">Payment by means of a card issued by a bank or other financial institution.</field>
 </record>
 
-<!-- Payment Mean 49 is not present in all versions:
-it is present in this version: http://www.unece.org/trade/untdid/d03a/tred/tred4461.htm
-but not in this one: http://www.unece.org/trade/untdid/d99b/tred/tred4461.htm
-But it is used in real life (cf Chorus specs for example: http://www.economie.gouv.fr/files/20160729_solution_portail_dossier_specificationsv3.24_versions_fr_et_en.zip), so we need it -->
 <record id="payment_means_49" model="unece.code.list">
     <field name="type">payment_means</field>
     <field name="code">49</field>
@@ -348,105 +351,175 @@ But it is used in real life (cf Chorus specs for example: http://www.economie.go
     <field name="type">payment_means</field>
     <field name="code">50</field>
     <field name="name">Payment by postgiro</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">A method for the transmission of funds through the postal system rather than through the banking system.</field>
+</record>
+
+<record id="payment_means_51" model="unece.code.list">
+    <field name="type">payment_means</field>
+    <field name="code">51</field>
+    <field name="name">FR, norme 6 97-Telereglement CFONB (French Organisation for Banking Standards) - Option A</field>
+    <field name="description">A French standard procedure that allows a debtor to pay an amount due to a creditor. The creditor will forward it to its bank, which will collect the money on the bank account of the debtor.</field>
+</record>
+
+<record id="payment_means_52" model="unece.code.list">
+    <field name="type">payment_means</field>
+    <field name="code">52</field>
+    <field name="name">Urgent commercial payment</field>
+    <field name="description">Payment order which requires guaranteed processing by the most appropriate means to ensure it occurs on the requested execution date, provided that it is issued to the ordered bank before the agreed cut-off time.</field>
+</record>
+
+<record id="payment_means_53" model="unece.code.list">
+    <field name="type">payment_means</field>
+    <field name="code">53</field>
+    <field name="name">Urgent Treasury Payment</field>
+    <field name="description">Payment order or transfer which must be executed, by the most appropriate means, as urgently as possible and before urgent commercial payments.</field>
+</record>
+
+<record id="payment_means_54" model="unece.code.list">
+    <field name="type">payment_means</field>
+    <field name="code">54</field>
+    <field name="name">Credit card</field>
+    <field name="description">Payment made by means of credit card.</field>
+</record>
+
+<record id="payment_means_55" model="unece.code.list">
+    <field name="type">payment_means</field>
+    <field name="code">55</field>
+    <field name="name">Debit card</field>
+    <field name="description">Payment made by means of debit card.</field>
+</record>
+
+<record id="payment_means_56" model="unece.code.list">
+    <field name="type">payment_means</field>
+    <field name="code">56</field>
+    <field name="name">Bankgiro</field>
+    <field name="description">Payment will be, or has been, made by bankgiro.</field>
+</record>
+
+<record id="payment_means_57" model="unece.code.list">
+    <field name="type">payment_means</field>
+    <field name="code">57</field>
+    <field name="name">Standing agreement</field>
+    <field name="description">The payment means have been previously agreed between seller and buyer and thus are not stated again.</field>
+</record>
+
+<record id="payment_means_58" model="unece.code.list">
+    <field name="type">payment_means</field>
+    <field name="code">58</field>
+    <field name="name">SEPA credit transfer</field>
+    <field name="description">Credit transfer inside the Single Euro Payment Area (SEPA) system.</field>
+</record>
+
+<record id="payment_means_59" model="unece.code.list">
+    <field name="type">payment_means</field>
+    <field name="code">59</field>
+    <field name="name">SEPA direct debit</field>
+    <field name="description">Direct debit inside the Single Euro Payment Area (SEPA) system.</field>
 </record>
 
 <record id="payment_means_60" model="unece.code.list">
     <field name="type">payment_means</field>
     <field name="code">60</field>
     <field name="name">Promissory note</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">Payment by an unconditional promise in writing made by one person to another, signed by the maker, engaging to pay on demand or at a fixed or determinable future time a sum certain in money, to order or to bearer.</field>
 </record>
 
 <record id="payment_means_61" model="unece.code.list">
     <field name="type">payment_means</field>
     <field name="code">61</field>
     <field name="name">Promissory note signed by the debtor</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">Payment by an unconditional promise in writing made by the debtor to another person, signed by the debtor, engaging to pay on demand or at a fixed or determinable future time a sum certain in money, to order or to bearer.</field>
 </record>
 
 <record id="payment_means_62" model="unece.code.list">
     <field name="type">payment_means</field>
     <field name="code">62</field>
     <field name="name">Promissory note signed by the debtor and endorsed by a bank</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">Payment by an unconditional promise in writing made by the debtor to another person, signed by the debtor and endorsed by a bank, engaging to pay on demand or at a fixed or determinable future time a sum certain in money, to order or to bearer.</field>
 </record>
 
 <record id="payment_means_63" model="unece.code.list">
     <field name="type">payment_means</field>
     <field name="code">63</field>
     <field name="name">Promissory note signed by the debtor and endorsed by a third party</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">Payment by an unconditional promise in writing made by the debtor to another person, signed by the debtor and endorsed by a third party, engaging to pay on demand or at a fixed or determinable future time a sum certain in money, to order or to bearer.</field>
 </record>
 
 <record id="payment_means_64" model="unece.code.list">
     <field name="type">payment_means</field>
     <field name="code">64</field>
     <field name="name">Promissory note signed by a bank</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">Payment by an unconditional promise in writing made by the bank to another person, signed by the bank, engaging to pay on demand or at a fixed or determinable future time a sum certain in money, to order or to bearer.</field>
 </record>
 
 <record id="payment_means_65" model="unece.code.list">
     <field name="type">payment_means</field>
     <field name="code">65</field>
     <field name="name">Promissory note signed by a bank and endorsed by another bank</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">Payment by an unconditional promise in writing made by the bank to another person, signed by the bank and endorsed by another bank, engaging to pay on demand or at a fixed or determinable future time a sum certain in money, to order or to bearer.</field>
 </record>
 
 <record id="payment_means_66" model="unece.code.list">
     <field name="type">payment_means</field>
     <field name="code">66</field>
     <field name="name">Promissory note signed by a third party</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">Payment by an unconditional promise in writing made by a third party to another person, signed by the third party, engaging to pay on demand or at a fixed or determinable future time a sum certain in money, to order or to bearer.</field>
 </record>
 
 <record id="payment_means_67" model="unece.code.list">
     <field name="type">payment_means</field>
     <field name="code">67</field>
     <field name="name">Promissory note signed by a third party and endorsed by a bank</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">Payment by an unconditional promise in writing made by a third party to another person, signed by the third party and endorsed by a bank, engaging to pay on demand or at a fixed or determinable future time a sum certain in money, to order or to bearer.</field>
+</record>
+
+<record id="payment_means_68" model="unece.code.list">
+    <field name="type">payment_means</field>
+    <field name="code">68</field>
+    <field name="name">Online payment service</field>
+    <field name="description">Payment will be made or has been made by an online payment service.</field>
 </record>
 
 <record id="payment_means_70" model="unece.code.list">
     <field name="type">payment_means</field>
     <field name="code">70</field>
     <field name="name">Bill drawn by the creditor on the debtor</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">Bill drawn by the creditor on the debtor.</field>
 </record>
 
 <record id="payment_means_74" model="unece.code.list">
     <field name="type">payment_means</field>
     <field name="code">74</field>
     <field name="name">Bill drawn by the creditor on a bank</field>
-    <field name="description">Description to be provided.</field>
+    <field name="description">Bill drawn by the creditor on a bank.</field>
 </record>
 
 <record id="payment_means_75" model="unece.code.list">
     <field name="type">payment_means</field>
     <field name="code">75</field>
     <field name="name">Bill drawn by the creditor, endorsed by another bank</field>
-    <field name="description">Description to be provided.</field>
+    <field name="description">Bill drawn by the creditor, endorsed by another bank.</field>
 </record>
 
 <record id="payment_means_76" model="unece.code.list">
     <field name="type">payment_means</field>
     <field name="code">76</field>
     <field name="name">Bill drawn by the creditor on a bank and endorsed by a third party</field>
-    <field name="description">Description to be provided.</field>
+    <field name="description">Bill drawn by the creditor on a bank and endorsed by a third party.</field>
 </record>
 
 <record id="payment_means_77" model="unece.code.list">
     <field name="type">payment_means</field>
     <field name="code">77</field>
     <field name="name">Bill drawn by the creditor on a third party</field>
-    <field name="description">Description to be provided.</field>
+    <field name="description">Bill drawn by the creditor on a third party.</field>
 </record>
 
 <record id="payment_means_78" model="unece.code.list">
     <field name="type">payment_means</field>
     <field name="code">78</field>
     <field name="name">Bill drawn by creditor on third party, accepted and endorsed by bank</field>
-    <field name="description">Description to be provided.</field>
+    <field name="description">Bill drawn by creditor on third party, accepted and endorsed by bank.</field>
 </record>
 
 <record id="payment_means_91" model="unece.code.list">
@@ -502,7 +575,7 @@ But it is used in real life (cf Chorus specs for example: http://www.economie.go
     <field name="type">payment_means</field>
     <field name="code">ZZZ</field>
     <field name="name">Mutually defined</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">A code assigned within a code list to be used on an interim basis and as defined among trading partners until a precise code can be assigned to the code list.</field>
 </record>
 
 

--- a/account_payment_unece/models/account_payment_method.py
+++ b/account_payment_unece/models/account_payment_method.py
@@ -16,4 +16,5 @@ class AccountPaymentMethod(models.Model):
         "Commission for Europe (UNECE) defined in UN/EDIFACT Data "
         "Element 4461")
     unece_code = fields.Char(
-        related='unece_id.code', store=True, string='UNECE Code')
+        related='unece_id.code', store=True, readonly=True,
+        string='UNECE Code')

--- a/account_tax_unece/__manifest__.py
+++ b/account_tax_unece/__manifest__.py
@@ -16,6 +16,7 @@
         'views/account_tax.xml',
         'data/unece_tax_type.xml',
         'data/unece_tax_categ.xml',
+        'data/unece_date.xml',
         ],
     'installable': True,
 }

--- a/account_tax_unece/__manifest__.py
+++ b/account_tax_unece/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     'name': 'Account Tax UNECE',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'category': 'Accounting & Finance',
     'license': 'AGPL-3',
     'summary': 'UNECE nomenclature for taxes',

--- a/account_tax_unece/data/unece_date.xml
+++ b/account_tax_unece/data/unece_date.xml
@@ -1,29 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo noupdate="0">
 
-<!-- unece.code.list
-Source : https://www.unece.org/fileadmin/DAM/trade/untdid/d16b/tred/tred2005.htm -->
+<!-- unece.code.list UNTDID 2475
+Source : https://www.unece.org/fileadmin/DAM/trade/untdid/d16b/tred/tred2475.htm
+The beta 1.1 version of Factur-X was using UNTDID 2005, but they changed it in
+September 2017 before the publication of the final version of Factur-X -->
 
-<!-- As there are several hundreads of entries in this nomenclature,
-I don't create all of them in Odoo for the moment, but only those that
+<!--
+I don't create the full nomenclature in Odoo for the moment, but only those that
 are used in the Factur-X standard. Feel free to add more if you need.
 In Factur-X, there are 2 possibilities for VAT on invoice date
-("TVA sur les débits" in French): code 2 or 3. We use 3 in Odoo for
+("TVA sur les débits" in French): code 5 or 29. We use 5 in Odoo for
 invoice generation and have a hack in the module
-account_invoice_import_factur-x to remap 2 on 3. -->
+account_invoice_import_factur-x to remap 29 on 5. -->
 
-<record id="date_3" model="unece.code.list">
+<record id="date_5" model="unece.code.list">
     <field name="type">date</field>
-    <field name="code">3</field>
-    <field name="name">Invoice document issue date time</field>
-    <field name="description">Date of issue of an invoice.</field>
+    <field name="code">5</field>
+    <field name="name">Date of invoice</field>
+    <field name="description">Payment time reference is date of invoice.</field>
 </record>
 
-<record id="date_432" model="unece.code.list">
+<record id="date_72" model="unece.code.list">
     <field name="type">date</field>
-    <field name="code">432</field>
-    <field name="name">Paid to date</field>
-    <field name="description">Date to which payments have been paid.</field>
+    <field name="code">72</field>
+    <field name="name">Payment date</field>
+    <field name="description">Date when a payment was made.</field>
 </record>
 
 

--- a/account_tax_unece/data/unece_date.xml
+++ b/account_tax_unece/data/unece_date.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="0">
+
+<!-- unece.code.list
+Source : https://www.unece.org/fileadmin/DAM/trade/untdid/d16b/tred/tred2005.htm -->
+
+<!-- As there are several hundreads of entries in this nomenclature,
+I don't create all of them in Odoo for the moment, but only those that
+are used in the Factur-X standard. Feel free to add more if you need. -->
+
+<record id="date_2" model="unece.code.list">
+    <field name="type">date</field>
+    <field name="code">2</field>
+    <field name="name">Delivery date/time, requested</field>
+    <field name="description">Date on which buyer requests goods to be delivered.</field>
+</record>
+
+<record id="date_3" model="unece.code.list">
+    <field name="type">date</field>
+    <field name="code">3</field>
+    <field name="name">Invoice document issue date time</field>
+    <field name="description">Date of issue of an invoice.</field>
+</record>
+
+<record id="date_432" model="unece.code.list">
+    <field name="type">date</field>
+    <field name="code">432</field>
+    <field name="name">Paid to date</field>
+    <field name="description">Date to which payments have been paid.</field>
+</record>
+
+
+</odoo>

--- a/account_tax_unece/data/unece_date.xml
+++ b/account_tax_unece/data/unece_date.xml
@@ -6,14 +6,11 @@ Source : https://www.unece.org/fileadmin/DAM/trade/untdid/d16b/tred/tred2005.htm
 
 <!-- As there are several hundreads of entries in this nomenclature,
 I don't create all of them in Odoo for the moment, but only those that
-are used in the Factur-X standard. Feel free to add more if you need. -->
-
-<record id="date_2" model="unece.code.list">
-    <field name="type">date</field>
-    <field name="code">2</field>
-    <field name="name">Delivery date/time, requested</field>
-    <field name="description">Date on which buyer requests goods to be delivered.</field>
-</record>
+are used in the Factur-X standard. Feel free to add more if you need.
+In Factur-X, there are 2 possibilities for VAT on invoice date
+("TVA sur les débits" in French): code 2 or 3. We use 3 in Odoo for
+invoice generation and have a hack in the module
+account_invoice_import_factur-x to remap 2 on 3. -->
 
 <record id="date_3" model="unece.code.list">
     <field name="type">date</field>

--- a/account_tax_unece/data/unece_tax_categ.xml
+++ b/account_tax_unece/data/unece_tax_categ.xml
@@ -8,7 +8,7 @@ Source : https://www.unece.org/fileadmin/DAM/trade/untdid/d16b/tred/tred5305.htm
     <field name="type">tax_categ</field>
     <field name="code">A</field>
     <field name="name">Mixed tax rate</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">Code specifying that the rate is based on mixed tax.</field>
 </record>
 
 <record id="tax_categ_aa" model="unece.code.list">
@@ -71,7 +71,7 @@ Source : https://www.unece.org/fileadmin/DAM/trade/untdid/d16b/tred/tred5305.htm
     <field name="type">tax_categ</field>
     <field name="code">E</field>
     <field name="name">Exempt from tax</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">Code specifying that taxes are not applicable.</field>
 </record>
 
 <record id="tax_categ_f" model="unece.code.list">
@@ -85,14 +85,14 @@ Source : https://www.unece.org/fileadmin/DAM/trade/untdid/d16b/tred/tred5305.htm
     <field name="type">tax_categ</field>
     <field name="code">G</field>
     <field name="name">Free export item, tax not charged</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">Code specifying that the item is free export and taxes are not charged.</field>
 </record>
 
 <record id="tax_categ_h" model="unece.code.list">
     <field name="type">tax_categ</field>
     <field name="code">H</field>
     <field name="name">Higher rate</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">Code specifying a higher rate of duty or tax or fee.</field>
 </record>
 
 <record id="tax_categ_i" model="unece.code.list">
@@ -134,21 +134,21 @@ Source : https://www.unece.org/fileadmin/DAM/trade/untdid/d16b/tred/tred5305.htm
     <field name="type">tax_categ</field>
     <field name="code">O</field>
     <field name="name">Services outside scope of tax</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">Code specifying that taxes are not applicable to the services.</field>
 </record>
 
 <record id="tax_categ_s" model="unece.code.list">
     <field name="type">tax_categ</field>
     <field name="code">S</field>
     <field name="name">Standard rate</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">Code specifying the standard rate.</field>
 </record>
 
 <record id="tax_categ_z" model="unece.code.list">
     <field name="type">tax_categ</field>
     <field name="code">Z</field>
     <field name="name">Zero rated goods</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">Code specifying that the goods are at a zero rate.</field>
 </record>
 
 

--- a/account_tax_unece/data/unece_tax_categ.xml
+++ b/account_tax_unece/data/unece_tax_categ.xml
@@ -2,7 +2,7 @@
 <odoo noupdate="0">
 
 <!-- unece.code.list
-Source : http://www.unece.org/trade/untdid/d97a/uncl/uncl5305.htm  -->
+Source : https://www.unece.org/fileadmin/DAM/trade/untdid/d16b/tred/tred5305.htm  -->
 
 <record id="tax_categ_a" model="unece.code.list">
     <field name="type">tax_categ</field>
@@ -39,6 +39,13 @@ Source : http://www.unece.org/trade/untdid/d97a/uncl/uncl5305.htm  -->
     <field name="description">A code to indicate that the Value Added Tax (VAT) amount of a previous invoice is to be paid.</field>
 </record>
 
+<record id="tax_categ_ae" model="unece.code.list">
+    <field name="type">tax_categ</field>
+    <field name="code">AE</field>
+    <field name="name">VAT Reverse Charge</field>
+    <field name="description">Code specifying that the standard VAT rate is levied from the invoicee.</field>
+</record>
+
 <record id="tax_categ_b" model="unece.code.list">
     <field name="type">tax_categ</field>
     <field name="code">B</field>
@@ -53,11 +60,25 @@ Source : http://www.unece.org/trade/untdid/d97a/uncl/uncl5305.htm  -->
     <field name="description">Duty associated with shipment of goods is paid by the supplier; customer receives goods with duty paid.</field>
 </record>
 
+<record id="tax_categ_d" model="unece.code.list">
+    <field name="type">tax_categ</field>
+    <field name="code">D</field>
+    <field name="name">Value Added Tax (VAT) margin scheme - travel agents</field>
+    <field name="description">Indication that the VAT margin scheme for travel agents is applied.</field>
+</record>
+
 <record id="tax_categ_e" model="unece.code.list">
     <field name="type">tax_categ</field>
     <field name="code">E</field>
     <field name="name">Exempt from tax</field>
     <field name="description">Self explanatory.</field>
+</record>
+
+<record id="tax_categ_f" model="unece.code.list">
+    <field name="type">tax_categ</field>
+    <field name="code">F</field>
+    <field name="name">Value Added Tax (VAT) margin scheme - second-hand goods</field>
+    <field name="description">Indication that the VAT margin scheme for second-hand goods is applied.</field>
 </record>
 
 <record id="tax_categ_g" model="unece.code.list">
@@ -72,6 +93,41 @@ Source : http://www.unece.org/trade/untdid/d97a/uncl/uncl5305.htm  -->
     <field name="code">H</field>
     <field name="name">Higher rate</field>
     <field name="description">Self explanatory.</field>
+</record>
+
+<record id="tax_categ_i" model="unece.code.list">
+    <field name="type">tax_categ</field>
+    <field name="code">I</field>
+    <field name="name">Value Added Tax (VAT) margin scheme - works of art</field>
+    <field name="description">Indication that the VAT margin scheme for works of art is applied.</field>
+</record>
+
+<record id="tax_categ_j" model="unece.code.list">
+    <field name="type">tax_categ</field>
+    <field name="code">J</field>
+    <field name="name">Value Added Tax (VAT) margin scheme - collector's items and antiques</field>
+    <field name="description">Indication that the VAT margin scheme for collector's items and antiques is applied.</field>
+</record>
+
+<record id="tax_categ_k" model="unece.code.list">
+    <field name="type">tax_categ</field>
+    <field name="code">K</field>
+    <field name="name">VAT exempt for EEA intra-community supply of goods and services</field>
+    <field name="description">A tax category code indicating the item is VAT exempt due to an intra-community supply in the European Economic Area.</field>
+</record>
+
+<record id="tax_categ_l" model="unece.code.list">
+    <field name="type">tax_categ</field>
+    <field name="code">L</field>
+    <field name="name">Canary Islands general indirect tax</field>
+    <field name="description">Impuesto General Indirecto Canario (IGIC) is an indirect tax levied on goods and services supplied in the Canary Islands (Spain) by traders and professionals, as well as on import of goods.</field>
+</record>
+
+<record id="tax_categ_m" model="unece.code.list">
+    <field name="type">tax_categ</field>
+    <field name="code">M</field>
+    <field name="name">Tax for production, services and importation in Ceuta and Melilla</field>
+    <field name="description">Impuesto sobre la Producción, los Servicios y la Importación (IPSI) is an indirect municipal tax, levied on the production, processing and import of all kinds of movable tangible property, the supply of services and the transfer of immovable property located in the cities of Ceuta and Melilla.</field>
 </record>
 
 <record id="tax_categ_o" model="unece.code.list">

--- a/account_tax_unece/data/unece_tax_type.xml
+++ b/account_tax_unece/data/unece_tax_type.xml
@@ -2,13 +2,13 @@
 <odoo noupdate="0">
 
 <!-- unece.code.list
-Source : http://www.unece.org/trade/untdid/d97b/uncl/uncl5153.htm  -->
+Source : https://www.unece.org/fileadmin/DAM/trade/untdid/d16b/tred/tred5153.htm  -->
 
 <record id="tax_type_aaa" model="unece.code.list">
     <field name="type">tax_type</field>
     <field name="code">AAA</field>
     <field name="name">Petroleum tax</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">A tax levied on the volume of petroleum being transacted.</field>
 </record>
 
 <record id="tax_type_aab" model="unece.code.list">
@@ -30,6 +30,69 @@ Source : http://www.unece.org/trade/untdid/d97b/uncl/uncl5153.htm  -->
     <field name="code">AAD</field>
     <field name="name">Tobacco tax</field>
     <field name="description">A tax levied on tobacco products.</field>
+</record>
+
+<record id="tax_type_aae" model="unece.code.list">
+    <field name="type">tax_type</field>
+    <field name="code">AAE</field>
+    <field name="name">Energy fee</field>
+    <field name="description">General fee or tax for the use of energy.</field>
+</record>
+
+<record id="tax_type_aaf" model="unece.code.list">
+    <field name="type">tax_type</field>
+    <field name="code">AAF</field>
+    <field name="name">Coffee tax</field>
+    <field name="description">A tax levied specifically on coffee products.</field>
+</record>
+
+<record id="tax_type_aag" model="unece.code.list">
+    <field name="type">tax_type</field>
+    <field name="code">AAG</field>
+    <field name="name">Harmonised sales tax, Canadian</field>
+    <field name="description">A harmonized sales tax consisting of a goods and service tax, a Canadian provincial sales tax and, as applicable, a Quebec sales tax which is recoverable.</field>
+</record>
+
+<record id="tax_type_aah" model="unece.code.list">
+    <field name="type">tax_type</field>
+    <field name="code">AAH</field>
+    <field name="name">Quebec sales tax</field>
+    <field name="description">A sales tax charged within the Canadian province of Quebec which is recoverable.</field>
+</record>
+
+<record id="tax_type_aai" model="unece.code.list">
+    <field name="type">tax_type</field>
+    <field name="code">AAI</field>
+    <field name="name">Canadian provincial sales tax</field>
+    <field name="description">A sales tax charged within Canadian provinces which is non-recoverable.</field>
+</record>
+
+<record id="tax_type_aaj" model="unece.code.list">
+    <field name="type">tax_type</field>
+    <field name="code">AAJ</field>
+    <field name="name">Tax on replacement part</field>
+    <field name="description">A tax levied on a replacement part, where the original part is returned.</field>
+</record>
+
+<record id="tax_type_aak" model="unece.code.list">
+    <field name="type">tax_type</field>
+    <field name="code">AAK</field>
+    <field name="name">Mineral oil tax</field>
+    <field name="description">Tax that is levied specifically on products containing mineral oil.</field>
+</record>
+
+<record id="tax_type_aal" model="unece.code.list">
+    <field name="type">tax_type</field>
+    <field name="code">AAL</field>
+    <field name="name">Special tax</field>
+    <field name="description">To indicate a special type of tax.</field>
+</record>
+
+<record id="tax_type_aam" model="unece.code.list">
+    <field name="type">tax_type</field>
+    <field name="code">AAM</field>
+    <field name="name">Insurance tax</field>
+    <field name="description">A tax levied specifically on insurances.</field>
 </record>
 
 <record id="tax_type_add" model="unece.code.list">
@@ -57,7 +120,7 @@ Source : http://www.unece.org/trade/untdid/d97b/uncl/uncl5153.htm  -->
     <field name="type">tax_type</field>
     <field name="code">CAR</field>
     <field name="name">Car tax</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">A tax that is levied on the value of the automobile.</field>
 </record>
 
 <record id="tax_type_coc" model="unece.code.list">
@@ -120,7 +183,7 @@ Source : http://www.unece.org/trade/untdid/d97b/uncl/uncl5153.htm  -->
     <field name="type">tax_type</field>
     <field name="code">FRE</field>
     <field name="name">Free</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">No tax levied.</field>
 </record>
 
 <record id="tax_type_gcn" model="unece.code.list">
@@ -155,7 +218,7 @@ Source : http://www.unece.org/trade/untdid/d97b/uncl/uncl5153.htm  -->
     <field name="type">tax_type</field>
     <field name="code">IND</field>
     <field name="name">Individual tax</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">A tax levied based on an individual's ability to pay.</field>
 </record>
 
 <record id="tax_type_lac" model="unece.code.list">
@@ -232,7 +295,7 @@ Source : http://www.unece.org/trade/untdid/d97b/uncl/uncl5153.htm  -->
     <field name="type">tax_type</field>
     <field name="code">PRF</field>
     <field name="name">Preference duty</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">Duties laid down in the Customs tariff, to which goods are liable on entering or leaving the Customs territory falling under a preferential regime such as Generalised System of Preferences (GSP).</field>
 </record>
 
 <record id="tax_type_scn" model="unece.code.list">
@@ -274,21 +337,21 @@ Source : http://www.unece.org/trade/untdid/d97b/uncl/uncl5153.htm  -->
     <field name="type">tax_type</field>
     <field name="code">SWT</field>
     <field name="name">Shifted wage tax</field>
-    <field name="description">Wage tax share of the invoice amount to be paid directly to the tax collector(s office).</field>
+    <field name="description">Wage tax share of the invoice amount to be paid directly to the tax collector's office).</field>
 </record>
 
 <record id="tax_type_tac" model="unece.code.list">
     <field name="type">tax_type</field>
     <field name="code">TAC</field>
     <field name="name">Alcohol mark tax</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">A tax levied based on the type of alcohol being obtained.</field>
 </record>
 
 <record id="tax_type_tot" model="unece.code.list">
     <field name="type">tax_type</field>
     <field name="code">TOT</field>
     <field name="name">Total</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">The summary amount of all taxes.</field>
 </record>
 
 <record id="tax_type_tox" model="unece.code.list">

--- a/account_tax_unece/models/account_tax.py
+++ b/account_tax_unece/models/account_tax.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# © 2016 Akretion (http://www.akretion.com)
+# © 2016-2017 Akretion (http://www.akretion.com)
 # @author: Alexis de Lattre <alexis.delattre@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
@@ -27,3 +27,15 @@ class AccountTax(models.Model):
     unece_categ_code = fields.Char(
         related='unece_categ_id.code', store=True,
         string='UNECE Category Code')
+    unece_due_date_id = fields.Many2one(
+        'unece.code.list', string='UNECE Due Date',
+        domain=[('type', '=', 'date')], ondelete='restrict',
+        help="Select the due date of that tax from the official "
+        "nomenclature of the United Nations Economic "
+        "Commission for Europe (UNECE), DataElement 2005. For a "
+        "sale VAT tax, it is the date on which that VAT is due to the "
+        "fiscal administration. For a purchase VAT tax, it is the date "
+        "on which that VAT can be deducted.")
+    unece_due_date_code = fields.Char(
+        related='unece_due_date_id.code', store=True,
+        string='UNECE Due Date Code')

--- a/account_tax_unece/models/account_tax.py
+++ b/account_tax_unece/models/account_tax.py
@@ -16,7 +16,7 @@ class AccountTax(models.Model):
         "nomenclature of the United Nations Economic "
         "Commission for Europe (UNECE), DataElement 5153")
     unece_type_code = fields.Char(
-        related='unece_type_id.code', store=True,
+        related='unece_type_id.code', store=True, readonly=True,
         string='UNECE Type Code')
     unece_categ_id = fields.Many2one(
         'unece.code.list', string='UNECE Tax Category',
@@ -25,7 +25,7 @@ class AccountTax(models.Model):
         "nomenclature of the United Nations Economic "
         "Commission for Europe (UNECE), DataElement 5305")
     unece_categ_code = fields.Char(
-        related='unece_categ_id.code', store=True,
+        related='unece_categ_id.code', store=True, readonly=True,
         string='UNECE Category Code')
     unece_due_date_id = fields.Many2one(
         'unece.code.list', string='UNECE Due Date',
@@ -37,5 +37,5 @@ class AccountTax(models.Model):
         "fiscal administration. For a purchase VAT tax, it is the date "
         "on which that VAT can be deducted.")
     unece_due_date_code = fields.Char(
-        related='unece_due_date_id.code', store=True,
+        related='unece_due_date_id.code', store=True, readonly=True,
         string='UNECE Due Date Code')

--- a/account_tax_unece/models/unece_code_list.py
+++ b/account_tax_unece/models/unece_code_list.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# © 2016 Akretion (http://www.akretion.com)
+# © 2016-2017 Akretion (http://www.akretion.com)
 # @author: Alexis de Lattre <alexis.delattre@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
@@ -12,4 +12,5 @@ class UneceCodeList(models.Model):
     type = fields.Selection(selection_add=[
         ('tax_type', 'Tax Types (UNCL 5153)'),
         ('tax_categ', 'Tax Categories (UNCL 5305)'),
+        ('date', 'Date, Time or Period Qualifier (UNTDID 2005)'),
         ])

--- a/account_tax_unece/views/account_tax.xml
+++ b/account_tax_unece/views/account_tax.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  © 2016 Akretion (http://www.akretion.com/)
+  © 2016-2017 Akretion (http://www.akretion.com/)
   @author Alexis de Lattre <alexis.delattre@akretion.com>
   License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 -->
@@ -16,6 +16,7 @@
         <group name="advanced_booleans" position="inside">
             <field name="unece_type_id" context="{'default_type': 'tax_type'}"/>
             <field name="unece_categ_id" context="{'default_type': 'tax_categ'}"/>
+            <field name="unece_due_date_id" context="{'default_type': 'date'}"/>
         </group>
     </field>
 </record>

--- a/base_unece/views/unece_code_list.xml
+++ b/base_unece/views/unece_code_list.xml
@@ -41,6 +41,9 @@
     <field name="model">unece.code.list</field>
     <field name="arch" type="xml">
         <search string="Search UNECE Code Lists">
+            <field name="name" string="Name or Code" filter_domain="['|', ('name', 'ilike', self), ('code', 'ilike', self)]"/>
+            <field name="code"/>
+            <field name="type"/>
             <group string="Group By" name="groupby">
                 <filter name="type_groupby" string="Type" context="{'group_by': 'type'}"/>
             </group>


### PR DESCRIPTION
This is required for Factur-X support, cf this PR https://github.com/OCA/edi/pull/22

Improve search view on unece code list.