### PR TITLE
[IMP][10.0] account_tax_unece: add unece type and category to tax template

### DIFF
--- a/account_tax_unece/README.rst
+++ b/account_tax_unece/README.rst
@@ -43,6 +43,7 @@ Contributors
 ------------
 
 * Alexis de Lattre <alexis.delattre@akretion.com>
+* Andrea Stirpe <a.stirpe@onestein.nl>
 
 Maintainer
 ----------

--- a/account_tax_unece/__manifest__.py
+++ b/account_tax_unece/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     'name': 'Account Tax UNECE',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.1.0',
     'category': 'Accounting & Finance',
     'license': 'AGPL-3',
     'summary': 'UNECE nomenclature for taxes',
@@ -14,6 +14,7 @@
     'depends': ['account', 'base_unece'],
     'data': [
         'views/account_tax.xml',
+        'views/account_tax_template.xml',
         'data/unece_tax_type.xml',
         'data/unece_tax_categ.xml',
         ],

--- a/account_tax_unece/models/__init__.py
+++ b/account_tax_unece/models/__init__.py
@@ -2,3 +2,4 @@
 
 from . import unece_code_list
 from . import account_tax
+from . import account_tax_template

--- a/account_tax_unece/models/account_tax_template.py
+++ b/account_tax_unece/models/account_tax_template.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Onestein (<http://www.onestein.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class AccountTaxTemplate(models.Model):
+    _inherit = 'account.tax.template'
+
+    unece_type_id = fields.Many2one(
+        'unece.code.list', string='UNECE Tax Type',
+        domain=[('type', '=', 'tax_type')],
+        help="Select the Tax Type Code of the official "
+        "nomenclature of the United Nations Economic "
+        "Commission for Europe (UNECE), DataElement 5153"
+    )
+    unece_categ_id = fields.Many2one(
+        'unece.code.list', string='UNECE Tax Category',
+        domain=[('type', '=', 'tax_categ')],
+        help="Select the Tax Category Code of the official "
+        "nomenclature of the United Nations Economic "
+        "Commission for Europe (UNECE), DataElement 5305"
+    )
+
+    def _get_tax_vals(self, company):
+        self.ensure_one()
+        res = super(AccountTaxTemplate, self)._get_tax_vals(company)
+        res['unece_type_id'] = self.unece_type_id.id or False
+        res['unece_categ_id'] = self.unece_categ_id.id or False
+        return res

--- a/account_tax_unece/views/account_tax_template.xml
+++ b/account_tax_unece/views/account_tax_template.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2017 Onestein (<http://www.onestein.eu>)
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<odoo>
+
+    <record id="view_tax_template_form" model="ir.ui.view">
+        <field name="model">account.tax.template</field>
+        <field name="inherit_id" ref="account.view_account_tax_template_form"/>
+        <field name="arch" type="xml">
+            <notebook position="inside">
+                <page string="Unece">
+                    <group name="unece">
+                        <group>
+                            <field name="unece_type_id" />
+                            <field name="unece_categ_id" />
+                        </group>
+                        <group>
+                        </group>
+                    </group>
+                </page>
+            </notebook>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
This is a proposal to add the fields `unece_type_id` and `unece_categ_id` to the tax template (model``account.tax.template``).

This way, when assigning a Chart of Account to a new company, the *UNECE Tax Type* and *UNECE Tax Category* will be automatically transferred to the taxes (model``account.tax``).

An example of module that makes use of such fields is this one: [l10n_nl_account_tax_unece](https://github.com/OCA/l10n-netherlands/pull/113)
