### PR TITLE
fix(base_iso3166): add codes of countries according to the code iso 3166

### DIFF
--- a/base_iso3166/README.rst
+++ b/base_iso3166/README.rst
@@ -1,5 +1,5 @@
 .. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
-   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :target: https://www.gnu.org/licenses/agpl-3.0-standalone.html
    :alt: License: AGPL-3
 
 ===========================
@@ -17,8 +17,8 @@ Check https://en.wikipedia.org/wiki/ISO_3166 for more info.
 Installation
 ============
 
-This module requires the Python library pycountry >= 0.19 (and < 16.10.23rc1) installed in the
-system.
+This module requires the Python library pycountry >= 0.19 installed in the
+system. It works also with pycountry >= 16.11.8
 
 Usage
 =====
@@ -29,18 +29,8 @@ Usage
 
 Known issues / Roadmap
 ======================
-Roadmap
--------
+
 * Include 3166-2 country subdivision codes
-
-Issue
------
-Since 16.10.23rc1 (new date version name) there is a breaking change in api: 
-
-  “alpha2”, “alpha4”, etc. are now using an underscore as that’s the pattern in the upstream packages. So it’s “alpha_2” now
-
-This odoo module is not currently up to date with this new api
-
 
 Bug Tracker
 ===========
@@ -48,11 +38,8 @@ Bug Tracker
 Bugs are tracked on `GitHub Issues
 <https://github.com/OCA/community-data-files/issues>`_. In case of trouble, please
 check there if your issue has already been reported. If you spotted it first,
-help us smashing it by providing a detailed and welcomed `feedback
-<https://github.com/OCA/
-community-data-files/issues/new?body=module:%20
-base_iso3166%0Aversion:%20
-8.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+help us smash it by providing detailed and welcomed feedback.
+
 
 Credits
 =======
@@ -61,6 +48,7 @@ Contributors
 ------------
 
 * Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
+* Enric Tobella <etobella@creublanca.es>
 
 Icon
 ----
@@ -70,9 +58,9 @@ Icon
 Maintainer
 ----------
 
-.. image:: http://odoo-community.org/logo.png
+.. image:: https://odoo-community.org/logo.png
    :alt: Odoo Community Association
-   :target: http://odoo-community.org
+   :target: https://odoo-community.org
 
 This module is maintained by the OCA.
 
@@ -80,4 +68,4 @@ OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
 
-To contribute to this module, please visit http://odoo-community.org.
+To contribute to this module, please visit https://odoo-community.org.

--- a/base_iso3166/__manifest__.py
+++ b/base_iso3166/__manifest__.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 # © 2016 Serv. Tecnol. Avanzados - Pedro M. Baeza
+# © 2017  Creu Blanca <www.creublanca.es>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 {
     "name": "ISO 3166",
-    "version": "8.0.1.0.0",
-    "author": "Serv. Tecnol. Avanzados - Pedro M. Baeza, "
+    "version": "10.0.1.0.0",
+    "author": "Tecnativa, "
+              "Creu Blanca, "
               "Odoo Community Association (OCA)",
     "category": "Localization",
     "website": "https://odoo-community.org",

--- a/base_iso3166/__openerp__.py
+++ b/base_iso3166/__openerp__.py
@@ -5,7 +5,7 @@
 
 {
     "name": "ISO 3166",
-    "version": "10.0.1.0.0",
+    "version": "8.0.1.0.1",
     "author": "Tecnativa, "
               "Creu Blanca, "
               "Odoo Community Association (OCA)",

--- a/base_iso3166/models/res_country.py
+++ b/base_iso3166/models/res_country.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 # © 2016 Serv. Tecnol. Avanzados - Pedro M. Baeza
+# © 2017  Creu Blanca <www.creublanca.es>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from openerp import api, fields, models
+from odoo import api, fields, models
+
 try:
     import pycountry
 except ImportError:
@@ -10,7 +12,6 @@ except ImportError:
 
 
 class ResCountry(models.Model):
-
     _inherit = 'res.country'
 
     code_alpha3 = fields.Char(
@@ -27,13 +28,23 @@ class ResCountry(models.Model):
     def _compute_codes(self):
         for country in self:
             try:
-                c = pycountry.countries.get(alpha2=country.code)
-                country.code_alpha3 = c.alpha3
+                try:
+                    c = pycountry.countries.get(alpha_2=country.code)
+                except KeyError:
+                    c = pycountry.countries.get(alpha2=country.code)
+                country.code_alpha3 = getattr(c, 'alpha_3',
+                                              getattr(c, 'alpha3', False))
                 country.code_numeric = c.numeric
             except KeyError:
                 try:
-                    c = pycountry.historic_countries.get(alpha2=country.code)
-                    country.code_alpha3 = c.alpha3
+                    try:
+                        c = pycountry.historic_countries.get(
+                            alpha_2=country.code)
+                    except KeyError:
+                        c = pycountry.historic_countries.get(
+                            alpha2=country.code)
+                    country.code_alpha3 = getattr(c, 'alpha_3',
+                                                  getattr(c, 'alpha3', False))
                     country.code_numeric = c.numeric
                 except KeyError:
                     country.code_alpha3 = False

--- a/base_iso3166/models/res_country.py
+++ b/base_iso3166/models/res_country.py
@@ -3,7 +3,7 @@
 # © 2017  Creu Blanca <www.creublanca.es>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import api, fields, models
+from openerp import api, fields, models
 
 try:
     import pycountry


### PR DESCRIPTION
modified res_country.py with the adjustments made for version 10 since it did not recognize the
two-letter code when inserting it for what it returned false. with this adaptation already shows the
codes to three characters according to the standard Iso 3166