### PR TITLE
[FIX][12.0][base_iso3166 ] make historic countries work

### DIFF
--- a/base_iso3166/README.rst
+++ b/base_iso3166/README.rst
@@ -79,6 +79,7 @@ Contributors
 * Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
 * Enric Tobella <etobella@creublanca.es>
 * Aitor Bouzas <aitor.bouzas@adaptivecity.com>
+* Joshua Jan <joshua@openerp.cn>
 
 Maintainers
 ~~~~~~~~~~~

--- a/base_iso3166/models/res_country.py
+++ b/base_iso3166/models/res_country.py
@@ -26,29 +26,23 @@ class ResCountry(models.Model):
     @api.depends('code')
     def _compute_codes(self):
         for country in self:
-            try:
+            c = False
+            for country_type in ['countries', 'historic_countries']:
                 try:
-                    c = pycountry.countries.get(alpha_2=country.code)
+                    c = getattr(pycountry, country_type).get(
+                        alpha_2=country.code)
                 except KeyError:
-                    c = pycountry.countries.get(alpha2=country.code)
-                if not c:
-                    continue
+                    try:
+                        c = getattr(pycountry, country_type).get(
+                            alpha2=country.code)
+                    except KeyError:
+                        pass
+                if c:
+                    break
+            if c:
                 country.code_alpha3 = getattr(c, 'alpha_3',
                                               getattr(c, 'alpha3', False))
                 country.code_numeric = c.numeric
-            except KeyError:
-                try:
-                    try:
-                        c = pycountry.historic_countries.get(
-                            alpha_2=country.code)
-                    except KeyError:
-                        c = pycountry.historic_countries.get(
-                            alpha2=country.code)
-                    if not c:
-                        continue
-                    country.code_alpha3 = getattr(c, 'alpha_3',
-                                                  getattr(c, 'alpha3', False))
-                    country.code_numeric = c.numeric
-                except KeyError:
-                    country.code_alpha3 = False
-                    country.code_numeric = False
+            else:
+                country.code_alpha3 = False
+                country.code_numeric = False

--- a/base_iso3166/readme/CONTRIBUTORS.rst
+++ b/base_iso3166/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
 * Enric Tobella <etobella@creublanca.es>
 * Aitor Bouzas <aitor.bouzas@adaptivecity.com>
+* Joshua Jan <joshua@openerp.cn>

--- a/base_iso3166/static/description/index.html
+++ b/base_iso3166/static/description/index.html
@@ -428,6 +428,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <li>Pedro M. Baeza &lt;<a class="reference external" href="mailto:pedro.baeza&#64;serviciosbaeza.com">pedro.baeza&#64;serviciosbaeza.com</a>&gt;</li>
 <li>Enric Tobella &lt;<a class="reference external" href="mailto:etobella&#64;creublanca.es">etobella&#64;creublanca.es</a>&gt;</li>
 <li>Aitor Bouzas &lt;<a class="reference external" href="mailto:aitor.bouzas&#64;adaptivecity.com">aitor.bouzas&#64;adaptivecity.com</a>&gt;</li>
+<li>Joshua Jan &lt;<a class="reference external" href="mailto:joshua&#64;openerp.cn">joshua&#64;openerp.cn</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">


### PR DESCRIPTION
Hello, This PR will fix this problem:

When the country code is not exist. This code will return False. 
`c = pycountry.countries.get(alpha_2=country.code)`

So the `c = pycountry.historic_countries.get(alpha_2=country.code)` will never be call. 

And it make the Test failed: E.g: https://travis-ci.org/OCA/community-data-files/jobs/479310840