### PR TITLE
IMP show acc_type on bank account list on partners

### DIFF
--- a/base_bank_from_iban/README.rst
+++ b/base_bank_from_iban/README.rst
@@ -23,7 +23,7 @@ Bank from IBAN
     :target: https://runbot.odoo-community.org/runbot/101/12.0
     :alt: Try me on Runbot
 
-|badge1| |badge2| |badge3| |badge4| |badge5| 
+|badge1| |badge2| |badge3| |badge4| |badge5|
 
 This module adds a code to bank definition for using it as matching for filling the bank
 from the IBAN bank account number. It uses the existing by country bank mapping in
@@ -49,7 +49,7 @@ Usage
 To use this module, you need to:
 
 #. Go to Partner
-#. Click *Bank Account(s)* in "Sales & Purchases" page.
+#. Click *Bank Account(s)* in "Invoicing" page.
 #. Create/modify IBAN bank account.
 #. When you put the bank account number, module extracts bank digits from the format of the country, and try to match an existing bank by country and code.
 #. If there's a match, the bank is selected automatically.

--- a/base_bank_from_iban/__manifest__.py
+++ b/base_bank_from_iban/__manifest__.py
@@ -15,6 +15,7 @@
     ],
     "data": [
         "views/res_bank_view.xml",
+        "views/res_partner_view.xml",
     ],
     'installable': True,
 }

--- a/base_bank_from_iban/views/res_partner_view.xml
+++ b/base_bank_from_iban/views/res_partner_view.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+
+    <record id="view_res_partner_acc_type_form" model="ir.ui.view">
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="account.view_partner_property_form"/>
+        <field name="arch" type="xml">
+            <field name="acc_number" position="after">
+                <field name="acc_type" />
+            </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
In version 12, you can create bank account directly on bank account list on partner form.

See account type directly on this list is usefull to check if bank account is iban or not.