### PR TITLE
[10.0] country.code_numeric = c.numeric, 'NoneType' object has no attribute 'numeric'

### DIFF
--- a/base_iso3166/models/res_country.py
+++ b/base_iso3166/models/res_country.py
@@ -32,9 +32,15 @@ class ResCountry(models.Model):
                     c = pycountry.countries.get(alpha_2=country.code)
                 except KeyError:
                     c = pycountry.countries.get(alpha2=country.code)
-                country.code_alpha3 = getattr(c, 'alpha_3',
-                                              getattr(c, 'alpha3', False))
-                country.code_numeric = c.numeric
+
+                country.code_alpha3 = getattr(
+                    c,
+                    'alpha_3',
+                    getattr(c, 'alpha3', False))
+                country.code_numeric = getattr(
+                    c,
+                    'numeric',
+                    getattr(c, 'numeric', False))
             except KeyError:
                 try:
                     try:
@@ -43,8 +49,11 @@ class ResCountry(models.Model):
                     except KeyError:
                         c = pycountry.historic_countries.get(
                             alpha2=country.code)
-                    country.code_alpha3 = getattr(c, 'alpha_3',
-                                                  getattr(c, 'alpha3', False))
+
+                    country.code_alpha3 = getattr(
+                        c,
+                        'alpha_3',
+                        getattr(c, 'alpha3', False))
                     country.code_numeric = c.numeric
                 except KeyError:
                     country.code_alpha3 = False


### PR DESCRIPTION
I have Odoo installed (OCB version 10.0), on ubuntu server 18.04 LTS, when we install the base_iso3166 module, the following error occurs:

OCA/community-data-files/base_iso3166/models/res_country.py", line 37, in _compute_codes
    country.code_numeric = c.numeric
AttributeError: 'NoneType' object has no attribute 'numeric'

To solve this error, it worked for me to make the change that I propose in this PR.