### PR TITLE
[13.0] [IMP] Base UNECE: allow search on code

### DIFF
--- a/base_unece/models/unece_code_list.py
+++ b/base_unece/models/unece_code_list.py
@@ -39,3 +39,13 @@ class UneceCodeList(models.Model):
         for entry in self:
             res.append((entry.id, "[{}] {}".format(entry.code, entry.name)))
         return res
+
+    @api.model
+    def name_search(self, name="", args=None, operator="ilike", limit=100):
+        args = args or []
+        recs = self.browse()
+        if name:
+            recs = self.search([("code", "=", name)] + args, limit=limit)
+        if not recs:
+            recs = self.search([("name", operator, name)] + args, limit=limit)
+        return recs.name_get()


### PR DESCRIPTION
Allow search on code (if code matched exactly), fallback on regular name search otherwise.