### PR TITLE
[IMP] l10n_eu_nace: add secondary

### DIFF
--- a/l10n_eu_nace/models/res_partner.py
+++ b/l10n_eu_nace/models/res_partner.py
@@ -9,5 +9,8 @@ class ResPartner(models.Model):
     _inherit = 'res.partner'
 
     nace_id = fields.Many2one(
-        comodel_name="res.partner.nace", string="NACE", index=True
+        comodel_name="res.partner.nace", string="Main NACE", index=True
+    )
+    secondary_nace_ids = fields.Many2many(
+        comodel_name="res.partner.nace", string="Secondary NACE"
     )

--- a/l10n_eu_nace/views/res_partner.xml
+++ b/l10n_eu_nace/views/res_partner.xml
@@ -12,6 +12,7 @@
             <xpath expr="//field[@name='category_id']" position="after">
                 <field name="nace_id"
                        options="{'always_reload': True}"/>
+                <field name="secondary_nace_ids" widget="many2many_tags"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Some need to add secondary NACE codes to partners.

This is a very little addition, possibly quite standard, so it's done directly in the base addon.

@Tecnativa TT17678