### PR TITLE
[8.0] [UPD] Backported more recent UNECE codes and descriptions from 10.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,31 @@
-sudo: false
-cache: pip
-
-addons:
-  apt:
-    packages:
-      - expect-dev  # provides unbuffer utility
-      - python-lxml # because pip installation is slow
-
 language: python
+cache:
+  directories:
+    - $HOME/.cache/pip
 
 python:
-  - "2.7"
+  - "2.7.13"
+
+addons:
+  postgresql: "9.6"
+  apt:
+    packages:
+      - expect-dev # provides unbuffer utility
+      - python-lxml  # because pip installation is slow
 
 env:
   global:
-     - VERSION="8.0" TESTS="0" LINT_CHECK="0" TRANSIFEX="0"
+    - VERSION="8.0" TESTS="0" LINT_CHECK="0" MAKEPOT="0"
   matrix:
-  - LINT_CHECK="1"
-  - TESTS="1" ODOO_REPO="odoo/odoo"
-  - TESTS="1" ODOO_REPO="OCA/OCB"
-
-virtualenv:
-  system_site_packages: true
+    - LINT_CHECK="1"
+    - TESTS="1" ODOO_REPO="odoo/odoo"
+    - TESTS="1" ODOO_REPO="OCA/OCB"
 
 install:
-  - git clone https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools
+  - git clone --depth=1 https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
   - travis_install_nightly
+  - pip install pypostcode
 
 script:
   - travis_run_tests

--- a/account_payment_unece/data/unece.xml
+++ b/account_payment_unece/data/unece.xml
@@ -3,13 +3,13 @@
 <data noupdate="0">
 
 <!-- unece.code.list
-Source : http://www.unece.org/trade/untdid/d99b/tred/tred4461.htm  -->
+Source : https://www.unece.org/fileadmin/DAM/trade/untdid/d16b/tred/tred4461.htm  -->
 
 <record id="payment_means_1" model="unece.code.list">
     <field name="type">payment_means</field>
     <field name="code">1</field>
     <field name="name">Instrument not defined</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">Not defined legally enforceable agreement between two or more parties (expressing a contractual right or a right to the payment of money).</field>
 </record>
 
 <record id="payment_means_2" model="unece.code.list">
@@ -72,7 +72,7 @@ Source : http://www.unece.org/trade/untdid/d99b/tred/tred4461.htm  -->
     <field name="type">payment_means</field>
     <field name="code">10</field>
     <field name="name">In cash</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">Payment by currency (including bills and coins) in circulation, including checking account deposits.</field>
 </record>
 
 <record id="payment_means_11" model="unece.code.list">
@@ -107,14 +107,14 @@ Source : http://www.unece.org/trade/untdid/d99b/tred/tred4461.htm  -->
     <field name="type">payment_means</field>
     <field name="code">15</field>
     <field name="name">Bookentry credit</field>
-    <field name="description">A credit transaction, initiated from the buyer's account to the seller's account at the save financial institution.</field>
+    <field name="description">A credit entry between two accounts at the same bank branch. Synonym: house credit.</field>
 </record>
 
 <record id="payment_means_16" model="unece.code.list">
     <field name="type">payment_means</field>
     <field name="code">16</field>
     <field name="name">Bookentry debit</field>
-    <field name="description">A debit transaction initiated from the seller's account to the seller's account at the same financial institution.</field>
+    <field name="description">A debit entry between two accounts at the same bank branch. Synonym: house debit.</field>
 </record>
 
 <record id="payment_means_17" model="unece.code.list">
@@ -142,7 +142,7 @@ Source : http://www.unece.org/trade/untdid/d99b/tred/tred4461.htm  -->
     <field name="type">payment_means</field>
     <field name="code">20</field>
     <field name="name">Cheque</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">Payment by a pre-printed form on which instructions are given to an account holder (a bank or building society) to pay a stated sum to a named recipient.</field>
 </record>
 
 <record id="payment_means_21" model="unece.code.list">
@@ -156,21 +156,28 @@ Source : http://www.unece.org/trade/untdid/d99b/tred/tred4461.htm  -->
     <field name="type">payment_means</field>
     <field name="code">22</field>
     <field name="name">Certified banker's draft</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">Cheque drawn by a bank on itself or its agent. A person who owes money to another buys the draft from a bank for cash and hands it to the creditor who need have no fear that it might be dishonoured.</field>
 </record>
 
 <record id="payment_means_23" model="unece.code.list">
     <field name="type">payment_means</field>
     <field name="code">23</field>
     <field name="name">Bank cheque (issued by a banking or similar establishment)</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">Payment by a pre-printed form, which has been completed by a financial institution, on which instructions are given to an account holder (a bank or building society) to pay a stated sum to a named recipient.</field>
+</record>
+
+<record id="payment_means_24" model="unece.code.list">
+    <field name="type">payment_means</field>
+    <field name="code">24</field>
+    <field name="name">Bill of exchange awaiting acceptance</field>
+    <field name="description">Bill drawn by the creditor on the debtor but not yet accepted by the debtor.</field>
 </record>
 
 <record id="payment_means_25" model="unece.code.list">
     <field name="type">payment_means</field>
     <field name="code">25</field>
     <field name="name">Certified cheque</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">Payment by a pre-printed form stamped with the paying bank's certification on which instructions are given to an account holder (a bank or building society) to pay a stated sum to a named recipient.</field>
 </record>
 
 <record id="payment_means_26" model="unece.code.list">
@@ -205,14 +212,14 @@ Source : http://www.unece.org/trade/untdid/d99b/tred/tred4461.htm  -->
     <field name="type">payment_means</field>
     <field name="code">30</field>
     <field name="name">Credit transfer</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">Payment by credit movement of funds from one account to another.</field>
 </record>
 
 <record id="payment_means_31" model="unece.code.list">
     <field name="type">payment_means</field>
     <field name="code">31</field>
     <field name="name">Debit transfer</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">Payment by debit movement of funds from one account to another.</field>
 </record>
 
 <record id="payment_means_32" model="unece.code.list">
@@ -289,7 +296,7 @@ Source : http://www.unece.org/trade/untdid/d99b/tred/tred4461.htm  -->
     <field name="type">payment_means</field>
     <field name="code">42</field>
     <field name="name">Payment to bank account</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">Payment by an arrangement for settling debts that is operated by the Post Office.</field>
 </record>
 
 <record id="payment_means_43" model="unece.code.list">
@@ -334,10 +341,6 @@ Source : http://www.unece.org/trade/untdid/d99b/tred/tred4461.htm  -->
     <field name="description">Payment by means of a card issued by a bank or other financial institution.</field>
 </record>
 
-<!-- Payment Mean 49 is not present in all versions:
-it is present in this version: http://www.unece.org/trade/untdid/d03a/tred/tred4461.htm
-but not in this one: http://www.unece.org/trade/untdid/d99b/tred/tred4461.htm
-But it is used in real life (cf Chorus specs for example: http://www.economie.gouv.fr/files/20160729_solution_portail_dossier_specificationsv3.24_versions_fr_et_en.zip), so we need it -->
 <record id="payment_means_49" model="unece.code.list">
     <field name="type">payment_means</field>
     <field name="code">49</field>
@@ -349,105 +352,175 @@ But it is used in real life (cf Chorus specs for example: http://www.economie.go
     <field name="type">payment_means</field>
     <field name="code">50</field>
     <field name="name">Payment by postgiro</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">A method for the transmission of funds through the postal system rather than through the banking system.</field>
+</record>
+
+<record id="payment_means_51" model="unece.code.list">
+    <field name="type">payment_means</field>
+    <field name="code">51</field>
+    <field name="name">FR, norme 6 97-Telereglement CFONB (French Organisation for Banking Standards) - Option A</field>
+    <field name="description">A French standard procedure that allows a debtor to pay an amount due to a creditor. The creditor will forward it to its bank, which will collect the money on the bank account of the debtor.</field>
+</record>
+
+<record id="payment_means_52" model="unece.code.list">
+    <field name="type">payment_means</field>
+    <field name="code">52</field>
+    <field name="name">Urgent commercial payment</field>
+    <field name="description">Payment order which requires guaranteed processing by the most appropriate means to ensure it occurs on the requested execution date, provided that it is issued to the ordered bank before the agreed cut-off time.</field>
+</record>
+
+<record id="payment_means_53" model="unece.code.list">
+    <field name="type">payment_means</field>
+    <field name="code">53</field>
+    <field name="name">Urgent Treasury Payment</field>
+    <field name="description">Payment order or transfer which must be executed, by the most appropriate means, as urgently as possible and before urgent commercial payments.</field>
+</record>
+
+<record id="payment_means_54" model="unece.code.list">
+    <field name="type">payment_means</field>
+    <field name="code">54</field>
+    <field name="name">Credit card</field>
+    <field name="description">Payment made by means of credit card.</field>
+</record>
+
+<record id="payment_means_55" model="unece.code.list">
+    <field name="type">payment_means</field>
+    <field name="code">55</field>
+    <field name="name">Debit card</field>
+    <field name="description">Payment made by means of debit card.</field>
+</record>
+
+<record id="payment_means_56" model="unece.code.list">
+    <field name="type">payment_means</field>
+    <field name="code">56</field>
+    <field name="name">Bankgiro</field>
+    <field name="description">Payment will be, or has been, made by bankgiro.</field>
+</record>
+
+<record id="payment_means_57" model="unece.code.list">
+    <field name="type">payment_means</field>
+    <field name="code">57</field>
+    <field name="name">Standing agreement</field>
+    <field name="description">The payment means have been previously agreed between seller and buyer and thus are not stated again.</field>
+</record>
+
+<record id="payment_means_58" model="unece.code.list">
+    <field name="type">payment_means</field>
+    <field name="code">58</field>
+    <field name="name">SEPA credit transfer</field>
+    <field name="description">Credit transfer inside the Single Euro Payment Area (SEPA) system.</field>
+</record>
+
+<record id="payment_means_59" model="unece.code.list">
+    <field name="type">payment_means</field>
+    <field name="code">59</field>
+    <field name="name">SEPA direct debit</field>
+    <field name="description">Direct debit inside the Single Euro Payment Area (SEPA) system.</field>
 </record>
 
 <record id="payment_means_60" model="unece.code.list">
     <field name="type">payment_means</field>
     <field name="code">60</field>
     <field name="name">Promissory note</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">Payment by an unconditional promise in writing made by one person to another, signed by the maker, engaging to pay on demand or at a fixed or determinable future time a sum certain in money, to order or to bearer.</field>
 </record>
 
 <record id="payment_means_61" model="unece.code.list">
     <field name="type">payment_means</field>
     <field name="code">61</field>
     <field name="name">Promissory note signed by the debtor</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">Payment by an unconditional promise in writing made by the debtor to another person, signed by the debtor, engaging to pay on demand or at a fixed or determinable future time a sum certain in money, to order or to bearer.</field>
 </record>
 
 <record id="payment_means_62" model="unece.code.list">
     <field name="type">payment_means</field>
     <field name="code">62</field>
     <field name="name">Promissory note signed by the debtor and endorsed by a bank</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">Payment by an unconditional promise in writing made by the debtor to another person, signed by the debtor and endorsed by a bank, engaging to pay on demand or at a fixed or determinable future time a sum certain in money, to order or to bearer.</field>
 </record>
 
 <record id="payment_means_63" model="unece.code.list">
     <field name="type">payment_means</field>
     <field name="code">63</field>
     <field name="name">Promissory note signed by the debtor and endorsed by a third party</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">Payment by an unconditional promise in writing made by the debtor to another person, signed by the debtor and endorsed by a third party, engaging to pay on demand or at a fixed or determinable future time a sum certain in money, to order or to bearer.</field>
 </record>
 
 <record id="payment_means_64" model="unece.code.list">
     <field name="type">payment_means</field>
     <field name="code">64</field>
     <field name="name">Promissory note signed by a bank</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">Payment by an unconditional promise in writing made by the bank to another person, signed by the bank, engaging to pay on demand or at a fixed or determinable future time a sum certain in money, to order or to bearer.</field>
 </record>
 
 <record id="payment_means_65" model="unece.code.list">
     <field name="type">payment_means</field>
     <field name="code">65</field>
     <field name="name">Promissory note signed by a bank and endorsed by another bank</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">Payment by an unconditional promise in writing made by the bank to another person, signed by the bank and endorsed by another bank, engaging to pay on demand or at a fixed or determinable future time a sum certain in money, to order or to bearer.</field>
 </record>
 
 <record id="payment_means_66" model="unece.code.list">
     <field name="type">payment_means</field>
     <field name="code">66</field>
     <field name="name">Promissory note signed by a third party</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">Payment by an unconditional promise in writing made by a third party to another person, signed by the third party, engaging to pay on demand or at a fixed or determinable future time a sum certain in money, to order or to bearer.</field>
 </record>
 
 <record id="payment_means_67" model="unece.code.list">
     <field name="type">payment_means</field>
     <field name="code">67</field>
     <field name="name">Promissory note signed by a third party and endorsed by a bank</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">Payment by an unconditional promise in writing made by a third party to another person, signed by the third party and endorsed by a bank, engaging to pay on demand or at a fixed or determinable future time a sum certain in money, to order or to bearer.</field>
+</record>
+
+<record id="payment_means_68" model="unece.code.list">
+    <field name="type">payment_means</field>
+    <field name="code">68</field>
+    <field name="name">Online payment service</field>
+    <field name="description">Payment will be made or has been made by an online payment service.</field>
 </record>
 
 <record id="payment_means_70" model="unece.code.list">
     <field name="type">payment_means</field>
     <field name="code">70</field>
     <field name="name">Bill drawn by the creditor on the debtor</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">Bill drawn by the creditor on the debtor.</field>
 </record>
 
 <record id="payment_means_74" model="unece.code.list">
     <field name="type">payment_means</field>
     <field name="code">74</field>
     <field name="name">Bill drawn by the creditor on a bank</field>
-    <field name="description">Description to be provided.</field>
+    <field name="description">Bill drawn by the creditor on a bank.</field>
 </record>
 
 <record id="payment_means_75" model="unece.code.list">
     <field name="type">payment_means</field>
     <field name="code">75</field>
     <field name="name">Bill drawn by the creditor, endorsed by another bank</field>
-    <field name="description">Description to be provided.</field>
+    <field name="description">Bill drawn by the creditor, endorsed by another bank.</field>
 </record>
 
 <record id="payment_means_76" model="unece.code.list">
     <field name="type">payment_means</field>
     <field name="code">76</field>
     <field name="name">Bill drawn by the creditor on a bank and endorsed by a third party</field>
-    <field name="description">Description to be provided.</field>
+    <field name="description">Bill drawn by the creditor on a bank and endorsed by a third party.</field>
 </record>
 
 <record id="payment_means_77" model="unece.code.list">
     <field name="type">payment_means</field>
     <field name="code">77</field>
     <field name="name">Bill drawn by the creditor on a third party</field>
-    <field name="description">Description to be provided.</field>
+    <field name="description">Bill drawn by the creditor on a third party.</field>
 </record>
 
 <record id="payment_means_78" model="unece.code.list">
     <field name="type">payment_means</field>
     <field name="code">78</field>
     <field name="name">Bill drawn by creditor on third party, accepted and endorsed by bank</field>
-    <field name="description">Description to be provided.</field>
+    <field name="description">Bill drawn by creditor on third party, accepted and endorsed by bank.</field>
 </record>
 
 <record id="payment_means_91" model="unece.code.list">
@@ -503,9 +576,8 @@ But it is used in real life (cf Chorus specs for example: http://www.economie.go
     <field name="type">payment_means</field>
     <field name="code">ZZZ</field>
     <field name="name">Mutually defined</field>
-    <field name="description">Self explanatory.</field>
+    <field name="description">A code assigned within a code list to be used on an interim basis and as defined among trading partners until a precise code can be assigned to the code list.</field>
 </record>
-
 
 <record id="account_banking_payment_export.manual_bank_tranfer" model="payment.mode.type">
     <field name="unece_id" ref="payment_means_31"/>


### PR DESCRIPTION
From [this commit](https://github.com/OCA/community-data-files/commit/0202b235898d376c0221a152c7f79f823862b73b#diff-fda77b93b0225e81515a852f5f5a5a06), basically a no-brainer.

I would have retained the commit author but it's all mangled up in one big migration commit.