### PR TITLE
[10.0][FIX] base_iso3166: Limit pycountry version for deprecated support

### DIFF
--- a/setup/base_iso3166/setup.py
+++ b/setup/base_iso3166/setup.py
@@ -2,5 +2,11 @@ import setuptools
 
 setuptools.setup(
     setup_requires=['setuptools-odoo'],
-    odoo_addon=True,
+    odoo_addon={
+        'external_dependencies_override': {
+            'python': {
+                'pycountry': 'pycountry<18.12.8',
+            },
+        },
+    },
 )


### PR DESCRIPTION
Stop pycountry version to current implementation.