### PR TITLE
[IMP] base_iso3166: Only add numeric if it exists

### DIFF
--- a/base_iso3166/models/res_country.py
+++ b/base_iso3166/models/res_country.py
@@ -42,7 +42,7 @@ class ResCountry(models.Model):
             if c:
                 country.code_alpha3 = getattr(c, 'alpha_3',
                                               getattr(c, 'alpha3', False))
-                country.code_numeric = c.numeric
+                country.code_numeric = getattr(c, 'numeric', False)
             else:
                 country.code_alpha3 = False
                 country.code_numeric = False


### PR DESCRIPTION
There are historic countries without numeric

@OCA/tools-maintainers 