### PR TITLE
[13.0][IMP] l10n_eu_product_adr: move fields to variant

### DIFF
--- a/l10n_eu_product_adr/README.rst
+++ b/l10n_eu_product_adr/README.rst
@@ -46,6 +46,14 @@ delivery
 May more complex name generation needed for computing shipping name, base on
 dangerous class
 
+Changelog
+=========
+
+13.0.2.0.1 (2021-06-08)
+=======================
+
+ - [BREAKING] Dangerous fields moved from `product.template` to `product.product` (`#112 <https://github.com/OCA/community-data-files/pull/112>`_)
+
 Bug Tracker
 ===========
 

--- a/l10n_eu_product_adr/__manifest__.py
+++ b/l10n_eu_product_adr/__manifest__.py
@@ -16,7 +16,7 @@
         "data/product_dangerous_class_data.xml",
         "data/utility_models_data.xml",
         "security/ir.model.access.csv",
-        "views/product_template_view.xml",
+        "views/product_product_view.xml",
         "views/product_dangerous.xml",
         "views/utility_models.xml",
     ],

--- a/l10n_eu_product_adr/models/__init__.py
+++ b/l10n_eu_product_adr/models/__init__.py
@@ -1,3 +1,3 @@
 from . import product_dangerous
-from . import product_template
+from . import product_product
 from . import utility_models

--- a/l10n_eu_product_adr/models/product_product.py
+++ b/l10n_eu_product_adr/models/product_product.py
@@ -20,8 +20,8 @@ LABELS_SELECTION = [
 TRANSPORT_CATEGORY = [("1", "0"), ("2", "1"), ("3", "2"), ("4", "3"), ("5", "4")]
 
 
-class ProductTemplate(models.Model):
-    _inherit = "product.template"
+class ProductProduct(models.Model):
+    _inherit = "product.product"
 
     is_dangerous = fields.Boolean(string="Dangerous product")
     dangerous_class_id = fields.Many2one(

--- a/l10n_eu_product_adr/readme/AUTHORS.rst
+++ b/l10n_eu_product_adr/readme/AUTHORS.rst
@@ -1,1 +1,2 @@
 Vyshnevska Iryna <i.vyshnevska@mobilunity.com>
+Matthieu Méquignon <matthieu.mequignon@camptocamp.com>

--- a/l10n_eu_product_adr/readme/DESCRIPTION.rst
+++ b/l10n_eu_product_adr/readme/DESCRIPTION.rst
@@ -5,3 +5,8 @@ and set weight and volume of this composition.
 Read more
 https://en.wikipedia.org/wiki/ADR_(treaty)
 Unece standards https://www.unece.org/trans/danger/publi/adr/adr2011/11ContentsE.html
+
+from 13.0.2.x.x
+===============
+
+ - [BREAKING] Dangerous fields moved from `product.template` to `product.product` (`#112 <https://github.com/OCA/community-data-files/pull/112>`_)

--- a/l10n_eu_product_adr/static/description/index.html
+++ b/l10n_eu_product_adr/static/description/index.html
@@ -377,24 +377,37 @@ Unece standards <a class="reference external" href="https://www.unece.org/trans/
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#known-issues-roadmap" id="id1">Known issues / Roadmap</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="id2">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="id3">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="id4">Authors</a></li>
-<li><a class="reference internal" href="#maintainers" id="id5">Maintainers</a></li>
+<li><a class="reference internal" href="#known-issues-roadmap" id="id3">Known issues / Roadmap</a></li>
+<li><a class="reference internal" href="#changelog" id="id4">Changelog</a></li>
+<li><a class="reference internal" href="#id1" id="id5">13.0.2.0.1 (2021-06-08)</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="id6">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="id7">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="id8">Authors</a></li>
+<li><a class="reference internal" href="#maintainers" id="id9">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
 <div class="section" id="known-issues-roadmap">
-<h1><a class="toc-backref" href="#id1">Known issues / Roadmap</a></h1>
+<h1><a class="toc-backref" href="#id3">Known issues / Roadmap</a></h1>
 <p>Dangerous products may also have temperature control to track goods in stock and
 delivery
 May more complex name generation needed for computing shipping name, base on
 dangerous class</p>
 </div>
+<div class="section" id="changelog">
+<h1><a class="toc-backref" href="#id4">Changelog</a></h1>
+</div>
+<div class="section" id="id1">
+<h1><a class="toc-backref" href="#id5">13.0.2.0.1 (2021-06-08)</a></h1>
+<blockquote>
+<ul class="simple">
+<li>[BREAKING] Dangerous fields moved from <cite>product.template</cite> to <cite>product.product</cite> (<a class="reference external" href="https://github.com/OCA/community-data-files/pull/112">#112</a>)</li>
+</ul>
+</blockquote>
+</div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#id2">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#id6">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/community-data-files/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed
@@ -402,15 +415,15 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#id3">Credits</a></h1>
+<h1><a class="toc-backref" href="#id7">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#id4">Authors</a></h2>
+<h2><a class="toc-backref" href="#id8">Authors</a></h2>
 <ul class="simple">
 <li>Camptocamp</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#id5">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#id9">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose

--- a/l10n_eu_product_adr/views/product_product_view.xml
+++ b/l10n_eu_product_adr/views/product_product_view.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
-    <record id="product_template_form_view" model="ir.ui.view">
-        <field name="name">product.template.dangerous.class</field>
-        <field name="model">product.template</field>
-        <field name="inherit_id" ref="product.product_template_form_view" />
+    <record id="product_normal_form_view" model="ir.ui.view">
+        <field name="name">product.product.form.inherit</field>
+        <field name="model">product.product</field>
+        <field name="inherit_id" ref="product.product_normal_form_view" />
         <field name="arch" type="xml">
             <xpath expr="//div[@name='options']" position="inside">
                 <div>

--- a/l10n_eu_product_adr/wizards/DG_product_handler.py
+++ b/l10n_eu_product_adr/wizards/DG_product_handler.py
@@ -112,7 +112,7 @@ class DGProductCounter(models.TransientModel):
                 {
                     "product": product,
                     "dg_unit": product.dg_unit.name,
-                    "class": product.product_tmpl_id.get_full_class_name()
+                    "class": product.get_full_class_name()
                     + ", {}, {}, {}, {}".format(
                         qty,
                         product.packaging_type_id.name,


### PR DESCRIPTION
Fields were defined on the template, but different variants attached to a same template could have different values.
This module moves "dangerous" fields on the `product.product` model.

This PR implement breaking change and this should be a major version increment. 