### PR TITLE
[13.0][ADD] adr product hook to filter move for report

### DIFF
--- a/l10n_eu_product_adr/wizards/DG_product_handler.py
+++ b/l10n_eu_product_adr/wizards/DG_product_handler.py
@@ -45,7 +45,7 @@ class DGProductCounter(models.TransientModel):
                 moves = pick.move_lines.filtered(lambda l: l.state == "done")
             else:
                 moves = pick.move_lines
-            dangerous_moves = moves.filtered(lambda self: self.product_id.is_dangerous)
+            dangerous_moves = self._filter_dangerous_move(moves)
             grouped_moves = groupby(
                 sorted(dangerous_moves, key=lambda l: l.product_id),
                 lambda r: r.product_id,
@@ -58,6 +58,10 @@ class DGProductCounter(models.TransientModel):
         )
         vals["total_section"]["warn"] = self._is_limit_exceeded(vals["total_section"])
         return vals
+
+    def _filter_dangerous_move(self, moves):
+        """Filter the moves to use for the report."""
+        return moves.filtered(lambda move: move.product_id.is_dangerous)
 
     def _compute_points_per_product(self, vals):
         index = {}.fromkeys(["1", "2", "3", "4", "5"], 0.0)


### PR DESCRIPTION
By default all moves related to dangerous product are used to generate
the report.
This PR adds a hook that allow to customize the filtering.