### PR TITLE
[FIX] account_tax_unece: fix migration path from 13.0

### DIFF
--- a/account_tax_unece/migrations/14.0.1.0.0/pre-migration.py
+++ b/account_tax_unece/migrations/14.0.1.0.0/pre-migration.py
@@ -1,0 +1,17 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+
+def migrate(cr, version):
+    if not version:
+        return
+    # Empty 'account_tax.unece_due_date_id' field as this column will be removed
+    # automatically post-migration.
+    # This avoids triggering the 'on delete restrict' foreign-key constraint
+    # when 'unece.code.list' records of type 'date' are removed from the database.
+    query = """
+        UPDATE account_tax
+        SET unece_due_date_id = NULL
+        WHERE unece_due_date_id IS NOT NULL;
+    """
+    cr.execute(query)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# generated from manifests external_dependencies
+pycountry


### PR DESCRIPTION
Since `unece.code.list` records of type `date` have been removed on
14.0, the upgrade to 14.0 is causing a constraint issue when Odoo is
removing these XML data records from the database while they could still
be used by `account.tax` records through the `unece_due_date_id` field.