### PR TITLE
[11.0] unece modules: backport improvements/updates from v14/v15

### DIFF
--- a/account_payment_unece/data/account_payment_method.xml
+++ b/account_payment_unece/data/account_payment_method.xml
@@ -2,11 +2,11 @@
 <odoo noupdate="1">
 
 <record id="account.account_payment_method_manual_in" model="account.payment.method">
-    <field name="unece_id" ref="payment_means_31"/>
+    <field name="unece_id" ref="payment_means_30"/>
 </record>
 
 <record id="account.account_payment_method_manual_out" model="account.payment.method">
-    <field name="unece_id" ref="payment_means_31"/>
+    <field name="unece_id" ref="payment_means_30"/>
 </record>
 
 </odoo>

--- a/account_payment_unece/i18n/account_payment_unece.pot
+++ b/account_payment_unece/i18n/account_payment_unece.pot
@@ -1,0 +1,42 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* account_payment_unece
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 11.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-07-01 16:20+0000\n"
+"PO-Revision-Date: 2022-07-01 16:20+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: account_payment_unece
+#: model:ir.model,name:account_payment_unece.model_account_payment_method
+msgid "Payment Methods"
+msgstr ""
+
+#. module: account_payment_unece
+#: model:ir.model.fields,help:account_payment_unece.field_account_payment_method_unece_id
+msgid "Standard nomenclature of the United Nations Economic Commission for Europe (UNECE) defined in UN/EDIFACT Data Element 4461"
+msgstr ""
+
+#. module: account_payment_unece
+#: model:ir.model.fields,field_description:account_payment_unece.field_account_payment_method_unece_code
+msgid "UNECE Code"
+msgstr ""
+
+#. module: account_payment_unece
+#: model:ir.model.fields,field_description:account_payment_unece.field_account_payment_method_unece_id
+msgid "UNECE Payment Mean"
+msgstr ""
+
+#. module: account_payment_unece
+#: model:ir.model,name:account_payment_unece.model_unece_code_list
+msgid "UNECE nomenclatures"
+msgstr ""
+

--- a/account_payment_unece/i18n/fr.po
+++ b/account_payment_unece/i18n/fr.po
@@ -1,0 +1,47 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* account_payment_unece
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 11.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-07-01 16:20+0000\n"
+"PO-Revision-Date: 2022-07-01 18:35+0200\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Poedit 2.3\n"
+"Last-Translator: \n"
+"Language: fr_FR\n"
+
+#. module: account_payment_unece
+#: model:ir.model,name:account_payment_unece.model_account_payment_method
+msgid "Payment Methods"
+msgstr "Méthodes de paiement"
+
+#. module: account_payment_unece
+#: model:ir.model.fields,help:account_payment_unece.field_account_payment_method_unece_id
+msgid ""
+"Standard nomenclature of the United Nations Economic Commission for Europe "
+"(UNECE) defined in UN/EDIFACT Data Element 4461"
+msgstr ""
+"Nomenclature standard de la Commission Économique des Nations Unies pour "
+"l’Europe (CEE-ONU) définie dans la Donnée EDIFACT-ONU 4461"
+
+#. module: account_payment_unece
+#: model:ir.model.fields,field_description:account_payment_unece.field_account_payment_method_unece_code
+msgid "UNECE Code"
+msgstr "Code CEE-ONU"
+
+#. module: account_payment_unece
+#: model:ir.model.fields,field_description:account_payment_unece.field_account_payment_method_unece_id
+msgid "UNECE Payment Mean"
+msgstr "Moyen de paiement CEE-ONU"
+
+#. module: account_payment_unece
+#: model:ir.model,name:account_payment_unece.model_unece_code_list
+msgid "UNECE nomenclatures"
+msgstr "Nomenclatures CEE-ONU"

--- a/account_payment_unece/views/account_payment_method.xml
+++ b/account_payment_unece/views/account_payment_method.xml
@@ -11,7 +11,8 @@
     <field name="inherit_id" ref="account_payment_mode.account_payment_method_form"/>
     <field name="arch" type="xml">
         <group name="main" position="inside">
-            <field name="unece_id" context="{'default_type': 'payment_means'}"/>
+            <field name="unece_id" context="{'default_type': 'payment_means'}"
+                options="{'no_create': True, 'no_create_edit': True}" />
         </group>
     </field>
 </record>

--- a/account_tax_unece/__manifest__.py
+++ b/account_tax_unece/__manifest__.py
@@ -16,7 +16,6 @@
         'views/account_tax_template.xml',
         'data/unece_tax_type.xml',
         'data/unece_tax_categ.xml',
-        'data/unece_date.xml',
         ],
     'installable': True,
 }

--- a/account_tax_unece/i18n/account_tax_unece.pot
+++ b/account_tax_unece/i18n/account_tax_unece.pot
@@ -1,0 +1,76 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* account_tax_unece
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 11.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-07-01 16:05+0000\n"
+"PO-Revision-Date: 2022-07-01 16:05+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: account_tax_unece
+#: model:ir.model,name:account_tax_unece.model_res_company
+msgid "Companies"
+msgstr ""
+
+#. module: account_tax_unece
+#: model:ir.model.fields,help:account_tax_unece.field_account_tax_template_unece_categ_id
+#: model:ir.model.fields,help:account_tax_unece.field_account_tax_unece_categ_id
+msgid "Select the Tax Category Code of the official nomenclature of the United Nations Economic Commission for Europe (UNECE), DataElement 5305"
+msgstr ""
+
+#. module: account_tax_unece
+#: model:ir.model.fields,help:account_tax_unece.field_account_tax_template_unece_type_id
+#: model:ir.model.fields,help:account_tax_unece.field_account_tax_unece_type_id
+msgid "Select the Tax Type Code of the official nomenclature of the United Nations Economic Commission for Europe (UNECE), DataElement 5153"
+msgstr ""
+
+#. module: account_tax_unece
+#: model:ir.model,name:account_tax_unece.model_account_tax
+msgid "Tax"
+msgstr ""
+
+#. module: account_tax_unece
+#: model:ir.model,name:account_tax_unece.model_account_tax_template
+msgid "Templates for Taxes"
+msgstr ""
+
+#. module: account_tax_unece
+#: model:ir.model.fields,field_description:account_tax_unece.field_account_tax_unece_categ_code
+msgid "UNECE Category Code"
+msgstr ""
+
+#. module: account_tax_unece
+#: model:ir.model.fields,field_description:account_tax_unece.field_account_tax_template_unece_categ_id
+#: model:ir.model.fields,field_description:account_tax_unece.field_account_tax_unece_categ_id
+msgid "UNECE Tax Category"
+msgstr ""
+
+#. module: account_tax_unece
+#: model:ir.model.fields,field_description:account_tax_unece.field_account_tax_template_unece_type_id
+#: model:ir.model.fields,field_description:account_tax_unece.field_account_tax_unece_type_id
+msgid "UNECE Tax Type"
+msgstr ""
+
+#. module: account_tax_unece
+#: model:ir.model.fields,field_description:account_tax_unece.field_account_tax_unece_type_code
+msgid "UNECE Type Code"
+msgstr ""
+
+#. module: account_tax_unece
+#: model:ir.model,name:account_tax_unece.model_unece_code_list
+msgid "UNECE nomenclatures"
+msgstr ""
+
+#. module: account_tax_unece
+#: model:ir.ui.view,arch_db:account_tax_unece.view_tax_template_form
+msgid "Unece"
+msgstr ""
+

--- a/account_tax_unece/i18n/fr.po
+++ b/account_tax_unece/i18n/fr.po
@@ -1,0 +1,86 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* account_tax_unece
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 11.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-07-01 16:05+0000\n"
+"PO-Revision-Date: 2022-07-01 18:17+0200\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Poedit 2.3\n"
+"Last-Translator: \n"
+"Language: fr_FR\n"
+
+#. module: account_tax_unece
+#: model:ir.model,name:account_tax_unece.model_res_company
+msgid "Companies"
+msgstr "Sociétés"
+
+#. module: account_tax_unece
+#: model:ir.model.fields,help:account_tax_unece.field_account_tax_template_unece_categ_id
+#: model:ir.model.fields,help:account_tax_unece.field_account_tax_unece_categ_id
+msgid ""
+"Select the Tax Category Code of the official nomenclature of the United "
+"Nations Economic Commission for Europe (UNECE), DataElement 5305"
+msgstr ""
+"Sélectionner le code de la catégorie de taxe de la nomenclature officielle "
+"de la Commission Économique des Nations Unies pour l’Europe (CEE-ONU), "
+"Donnée 5305"
+
+#. module: account_tax_unece
+#: model:ir.model.fields,help:account_tax_unece.field_account_tax_template_unece_type_id
+#: model:ir.model.fields,help:account_tax_unece.field_account_tax_unece_type_id
+msgid ""
+"Select the Tax Type Code of the official nomenclature of the United Nations "
+"Economic Commission for Europe (UNECE), DataElement 5153"
+msgstr ""
+"Sélectionner le code du type de taxe de la nomenclature officielle de la "
+"Commission Économique des Nations Unies pour l’Europe (CEE-ONU), Donnée 5153"
+
+#. module: account_tax_unece
+#: model:ir.model,name:account_tax_unece.model_account_tax
+msgid "Tax"
+msgstr "Taxe"
+
+#. module: account_tax_unece
+#: model:ir.model,name:account_tax_unece.model_account_tax_template
+msgid "Templates for Taxes"
+msgstr "Modèles de taxes"
+
+#. module: account_tax_unece
+#: model:ir.model.fields,field_description:account_tax_unece.field_account_tax_unece_categ_code
+msgid "UNECE Category Code"
+msgstr "Code de catégorie CEE-ONU"
+
+#. module: account_tax_unece
+#: model:ir.model.fields,field_description:account_tax_unece.field_account_tax_template_unece_categ_id
+#: model:ir.model.fields,field_description:account_tax_unece.field_account_tax_unece_categ_id
+msgid "UNECE Tax Category"
+msgstr "Catégorie de taxe CEE-ONU"
+
+#. module: account_tax_unece
+#: model:ir.model.fields,field_description:account_tax_unece.field_account_tax_template_unece_type_id
+#: model:ir.model.fields,field_description:account_tax_unece.field_account_tax_unece_type_id
+msgid "UNECE Tax Type"
+msgstr "Type de taxe CEE-ONU"
+
+#. module: account_tax_unece
+#: model:ir.model.fields,field_description:account_tax_unece.field_account_tax_unece_type_code
+msgid "UNECE Type Code"
+msgstr "Code de type CEE-ONU"
+
+#. module: account_tax_unece
+#: model:ir.model,name:account_tax_unece.model_unece_code_list
+msgid "UNECE nomenclatures"
+msgstr "Nomenclatures CEE-ONU"
+
+#. module: account_tax_unece
+#: model:ir.ui.view,arch_db:account_tax_unece.view_tax_template_form
+msgid "Unece"
+msgstr "CEE-ONU"

--- a/account_tax_unece/models/__init__.py
+++ b/account_tax_unece/models/__init__.py
@@ -3,3 +3,4 @@
 from . import unece_code_list
 from . import account_tax
 from . import account_tax_template
+from . import res_company

--- a/account_tax_unece/models/account_tax_template.py
+++ b/account_tax_unece/models/account_tax_template.py
@@ -24,10 +24,7 @@ class AccountTaxTemplate(models.Model):
 
     def _get_tax_vals(self, company, tax_template_to_tax):
         self.ensure_one()
-        res = super(AccountTaxTemplate, self)._get_tax_vals(
-            company,
-            tax_template_to_tax
-        )
+        res = super()._get_tax_vals(company, tax_template_to_tax)
         res['unece_type_id'] = self.unece_type_id.id or False
         res['unece_categ_id'] = self.unece_categ_id.id or False
         return res

--- a/account_tax_unece/models/res_company.py
+++ b/account_tax_unece/models/res_company.py
@@ -1,0 +1,56 @@
+# Copyright 2020 Akretion France (http://www.akretion.com)
+# @author: Alexis de Lattre <alexis.delattre@akretion.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    def _get_tax_unece_speeddict(self):
+        self.ensure_one()
+        res = {}
+        tax_obj = self.env["account.tax"]
+        all_taxes = tax_obj.with_context(active_test=False).search_read(
+            [("company_id", "=", self.id)],
+            [
+                "unece_type_code",
+                "unece_categ_code",
+                "tax_exigibility",
+                "amount",
+                "amount_type",
+                "name",
+                "display_name",
+            ],
+        )
+        for tax in all_taxes:
+            res[tax["id"]] = {
+                "unece_type_code": tax["unece_type_code"] or None,
+                "unece_categ_code": tax["unece_categ_code"] or None,
+                "unece_due_date_code": None,
+                "amount_type": tax["amount_type"],
+                "amount": tax["amount"],
+                "name": tax["name"],
+                "display_name": tax["display_name"],
+            }
+            if tax["tax_exigibility"]:
+                res[tax["id"]][
+                    "unece_due_date_code"
+                ] = tax_obj._get_unece_code_from_tax_exigibility(tax["tax_exigibility"])
+        return res
+
+    def _get_fiscal_position_speeddict(self, lang):
+        self.ensure_one()
+        res = {}
+        fp_obj = self.env["account.fiscal.position"]
+        fpositions = fp_obj.with_context(lang=lang, active_test=False).search_read(
+            [("company_id", "=", self.id)], ["name", "display_name", "note"]
+        )
+        for fp in fpositions:
+            res[fp["id"]] = {
+                "name": fp["name"],
+                "display_name": fp["display_name"],
+                "note": fp["note"],  # supposed to store the exemption reason
+            }
+        return res

--- a/account_tax_unece/models/unece_code_list.py
+++ b/account_tax_unece/models/unece_code_list.py
@@ -11,5 +11,4 @@ class UneceCodeList(models.Model):
     type = fields.Selection(selection_add=[
         ('tax_type', 'Tax Types (UNCL 5153)'),
         ('tax_categ', 'Tax Categories (UNCL 5305)'),
-        ('date', 'Date, Time or Period Qualifier (UNTDID 2005)'),
         ])

--- a/account_tax_unece/views/account_tax.xml
+++ b/account_tax_unece/views/account_tax.xml
@@ -14,9 +14,10 @@
     <field name="inherit_id" ref="account.view_tax_form"/>
     <field name="arch" type="xml">
         <group name="advanced_booleans" position="inside">
-            <field name="unece_type_id" context="{'default_type': 'tax_type'}"/>
-            <field name="unece_categ_id" context="{'default_type': 'tax_categ'}"/>
-            <field name="unece_due_date_id" context="{'default_type': 'date'}"/>
+            <field name="unece_type_id" context="{'default_type': 'tax_type'}"
+                options="{'no_create': True, 'no_create_edit': True}" />
+            <field name="unece_categ_id" context="{'default_type': 'tax_categ'}"
+                options="{'no_create': True, 'no_create_edit': True}" />
         </group>
     </field>
 </record>

--- a/account_tax_unece/views/account_tax_template.xml
+++ b/account_tax_unece/views/account_tax_template.xml
@@ -12,8 +12,10 @@
                 <page string="Unece">
                     <group name="unece">
                         <group>
-                            <field name="unece_type_id" />
-                            <field name="unece_categ_id" />
+                            <field name="unece_type_id"
+                               options="{'no_create': True, 'no_create_edit': True}"/>
+                            <field name="unece_categ_id"
+                               options="{'no_create': True, 'no_create_edit': True}"/>
                         </group>
                         <group>
                         </group>

--- a/base_unece/i18n/base_unece.pot
+++ b/base_unece/i18n/base_unece.pot
@@ -1,0 +1,124 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* base_unece
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 11.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-07-01 16:03+0000\n"
+"PO-Revision-Date: 2022-07-01 16:03+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: base_unece
+#: model:ir.model.fields,field_description:base_unece.field_unece_code_list_active
+msgid "Active"
+msgstr ""
+
+#. module: base_unece
+#: sql_constraint:unece.code.list:0
+msgid "An UNECE code of the same type already exists"
+msgstr ""
+
+#. module: base_unece
+#: model:ir.ui.view,arch_db:base_unece.unece_code_list_search
+msgid "Archived"
+msgstr ""
+
+#. module: base_unece
+#: model:ir.model.fields,field_description:base_unece.field_unece_code_list_code
+msgid "Code"
+msgstr ""
+
+#. module: base_unece
+#: model:ir.model.fields,field_description:base_unece.field_unece_code_list_create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: base_unece
+#: model:ir.model.fields,field_description:base_unece.field_unece_code_list_create_date
+msgid "Created on"
+msgstr ""
+
+#. module: base_unece
+#: model:ir.model.fields,field_description:base_unece.field_unece_code_list_description
+msgid "Description"
+msgstr ""
+
+#. module: base_unece
+#: model:ir.model.fields,field_description:base_unece.field_unece_code_list_display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: base_unece
+#: model:ir.ui.view,arch_db:base_unece.unece_code_list_search
+msgid "Group By"
+msgstr ""
+
+#. module: base_unece
+#: model:ir.model.fields,field_description:base_unece.field_unece_code_list_id
+msgid "ID"
+msgstr ""
+
+#. module: base_unece
+#: model:ir.model.fields,field_description:base_unece.field_unece_code_list___last_update
+msgid "Last Modified on"
+msgstr ""
+
+#. module: base_unece
+#: model:ir.model.fields,field_description:base_unece.field_unece_code_list_write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: base_unece
+#: model:ir.model.fields,field_description:base_unece.field_unece_code_list_write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: base_unece
+#: model:ir.model.fields,field_description:base_unece.field_unece_code_list_name
+msgid "Name"
+msgstr ""
+
+#. module: base_unece
+#: model:ir.ui.view,arch_db:base_unece.unece_code_list_search
+msgid "Name or Code"
+msgstr ""
+
+#. module: base_unece
+#: selection:unece.code.list,type:0
+msgid "Payment Means (UNCL 4461)"
+msgstr ""
+
+#. module: base_unece
+#: selection:unece.code.list,type:0
+msgid "Tax Categories (UNCL 5305)"
+msgstr ""
+
+#. module: base_unece
+#: selection:unece.code.list,type:0
+msgid "Tax Types (UNCL 5153)"
+msgstr ""
+
+#. module: base_unece
+#: model:ir.model.fields,field_description:base_unece.field_unece_code_list_type
+#: model:ir.ui.view,arch_db:base_unece.unece_code_list_search
+msgid "Type"
+msgstr ""
+
+#. module: base_unece
+#: model:ir.actions.act_window,name:base_unece.unece_code_list_action
+#: model:ir.ui.menu,name:base_unece.unece_code_list_menu
+msgid "UNECE Code Lists"
+msgstr ""
+
+#. module: base_unece
+#: model:ir.model,name:base_unece.model_unece_code_list
+msgid "UNECE nomenclatures"
+msgstr ""
+

--- a/base_unece/i18n/fr.po
+++ b/base_unece/i18n/fr.po
@@ -1,0 +1,125 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* base_unece
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 11.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-07-01 16:03+0000\n"
+"PO-Revision-Date: 2022-07-01 18:04+0200\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: fr_FR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Poedit 2.3\n"
+
+#. module: base_unece
+#: model:ir.model.fields,field_description:base_unece.field_unece_code_list_active
+msgid "Active"
+msgstr "Actif"
+
+#. module: base_unece
+#: sql_constraint:unece.code.list:0
+msgid "An UNECE code of the same type already exists"
+msgstr "Un code CEE-ONU de type identique existe déjà"
+
+#. module: base_unece
+#: model:ir.ui.view,arch_db:base_unece.unece_code_list_search
+msgid "Archived"
+msgstr "Archivé"
+
+#. module: base_unece
+#: model:ir.model.fields,field_description:base_unece.field_unece_code_list_code
+msgid "Code"
+msgstr "Code"
+
+#. module: base_unece
+#: model:ir.model.fields,field_description:base_unece.field_unece_code_list_create_uid
+msgid "Created by"
+msgstr "Créé par"
+
+#. module: base_unece
+#: model:ir.model.fields,field_description:base_unece.field_unece_code_list_create_date
+msgid "Created on"
+msgstr "Créé le"
+
+#. module: base_unece
+#: model:ir.model.fields,field_description:base_unece.field_unece_code_list_description
+msgid "Description"
+msgstr "Description"
+
+#. module: base_unece
+#: model:ir.model.fields,field_description:base_unece.field_unece_code_list_display_name
+msgid "Display Name"
+msgstr "Nom d’affichage"
+
+#. module: base_unece
+#: model:ir.ui.view,arch_db:base_unece.unece_code_list_search
+msgid "Group By"
+msgstr "Regrouper par…"
+
+#. module: base_unece
+#: model:ir.model.fields,field_description:base_unece.field_unece_code_list_id
+msgid "ID"
+msgstr "ID"
+
+#. module: base_unece
+#: model:ir.model.fields,field_description:base_unece.field_unece_code_list___last_update
+msgid "Last Modified on"
+msgstr "Dernière modification le"
+
+#. module: base_unece
+#: model:ir.model.fields,field_description:base_unece.field_unece_code_list_write_uid
+msgid "Last Updated by"
+msgstr "Dernière mise à jour par"
+
+#. module: base_unece
+#: model:ir.model.fields,field_description:base_unece.field_unece_code_list_write_date
+msgid "Last Updated on"
+msgstr "Dernière mise à jour le"
+
+#. module: base_unece
+#: model:ir.model.fields,field_description:base_unece.field_unece_code_list_name
+msgid "Name"
+msgstr "Nom"
+
+#. module: base_unece
+#: model:ir.ui.view,arch_db:base_unece.unece_code_list_search
+msgid "Name or Code"
+msgstr "Nom ou Code"
+
+#. module: base_unece
+#: selection:unece.code.list,type:0
+msgid "Payment Means (UNCL 4461)"
+msgstr "Moyens de paiement (UNCL 4461)"
+
+#. module: base_unece
+#: selection:unece.code.list,type:0
+msgid "Tax Categories (UNCL 5305)"
+msgstr "Catégories de taxe (UNCL 5305)"
+
+#. module: base_unece
+#: selection:unece.code.list,type:0
+msgid "Tax Types (UNCL 5153)"
+msgstr "Types de taxe (UNCL 5153)"
+
+#. module: base_unece
+#: model:ir.model.fields,field_description:base_unece.field_unece_code_list_type
+#: model:ir.ui.view,arch_db:base_unece.unece_code_list_search
+msgid "Type"
+msgstr "Type"
+
+#. module: base_unece
+#: model:ir.actions.act_window,name:base_unece.unece_code_list_action
+#: model:ir.ui.menu,name:base_unece.unece_code_list_menu
+msgid "UNECE Code Lists"
+msgstr "Listes de codes CEE-ONU"
+
+#. module: base_unece
+#: model:ir.model,name:base_unece.model_unece_code_list
+msgid "UNECE nomenclatures"
+msgstr "Nomenclatures CEE-ONU"

--- a/base_unece/views/unece_code_list.xml
+++ b/base_unece/views/unece_code_list.xml
@@ -13,10 +13,18 @@
     <field name="arch" type="xml">
         <form>
             <sheet>
+                <div class="oe_button_box" name="button_box">
+                    <button name="toggle_active" type="object"
+                        class="oe_stat_button" icon="fa-archive">
+                        <field name="active" widget="boolean_button"
+                            options='{"terminology": "archive"}'/>
+                    </button>
+                </div>
                 <group name="main">
                     <group name="general">
                         <field name="code"/>
                         <field name="name"/>
+                        <field name="active" invisible="1"/>
                     </group>
                     <group name="extra">
                         <field name="type"/>
@@ -47,6 +55,8 @@
             <field name="name" string="Name or Code" filter_domain="['|', ('name', 'ilike', self), ('code', 'ilike', self)]"/>
             <field name="code"/>
             <field name="type"/>
+            <separator/>
+            <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
             <group string="Group By" name="groupby">
                 <filter name="type_groupby" string="Type" context="{'group_by': 'type'}"/>
             </group>


### PR DESCRIPTION
account_tax_unece: remove field unece_due_date_id from account.tax to
use the native field tax_exigibility
account_payment_unece: use 30 by default on wire transfert instead of 31
base_unece: add active field