### PR TITLE
[14.0] Add l10n_eu_product_adr_dangerous_goods

### DIFF
--- a/l10n_eu_product_adr/migrations/14.0.1.0.0/post-migration.py
+++ b/l10n_eu_product_adr/migrations/14.0.1.0.0/post-migration.py
@@ -1,0 +1,37 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+"""Sets the adr goods id on the products according to their
+adr_number / transport_category (set in the pre migration script).
+
+This is required because the information has been lost in the
+l10n_eu_product_adr migration process
+"""
+
+
+def assign_adr_class(cr):
+    query = """
+        UPDATE product_product
+        SET adr_goods_id = subquery.adr_goods_id
+        FROM (
+            SELECT ag.id as adr_goods_id, array_agg(pp.id) as product_ids
+            FROM product_product pp
+            INNER JOIN adr_goods ag ON (
+                pp.adr_number = ag.un_number
+                AND pp.transport_category = ag.transport_category
+            )
+            WHERE pp.adr_number IS NOT NULL
+            GROUP BY ag.id
+        ) AS subquery
+        WHERE product_product.id = ANY(subquery.product_ids);
+    """
+    cr.execute(query)
+
+
+def cleanup_adr_code(cr):
+    cr.execute("ALTER TABLE product_product DROP adr_number;")
+
+
+def migrate(cr, version):
+    assign_adr_class(cr)
+    cleanup_adr_code(cr)

--- a/l10n_eu_product_adr/migrations/14.0.1.0.0/pre-migration.py
+++ b/l10n_eu_product_adr/migrations/14.0.1.0.0/pre-migration.py
@@ -1,0 +1,126 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+import logging
+
+_logger = logging.getLogger(__name__)
+
+try:
+    from openupgradelib import openupgrade
+except (ImportError, IOError) as err:
+    _logger.debug(err)
+
+
+PREVIOUS_MODULE_NAME = "l10n_eu_product_adr"
+NEW_MODULE_NAME = "l10n_eu_product_adr_dangerous_good"
+
+
+QUERY_GET_NAMES = """
+    SELECT name
+    FROM ir_model_data
+    WHERE module = %s
+    AND model in %s;
+"""
+
+FIELD_NAMES_TO_MOVE = {
+    "product.product": [
+        "limited_amount_id",
+        "content_package",
+        "nag",
+        "veva_code_empty",
+        "veva_code_full",
+        "storage_class_id",
+        "packaging_type_id",
+        "storage_temp_id",
+        "flash_point",
+        "wgk_class_id",
+        "h_no",
+        "envir_hazardous ",
+        "packaging_group ",
+        "hazard_ind ",
+        "voc ",
+        "content_package ",
+        "label_first ",
+        "label_second ",
+        "label_third ",
+        "dg_unit",
+    ],
+}
+MODELS_TO_MOVE = (
+    "storage.class",
+    "packaging.type",
+    "storage.temp",
+    "wgk.class",
+    "limited.amount",
+    "dangerous.uom",
+)
+
+
+def move_fields_to_new_module(cr):
+    for model, field_names in FIELD_NAMES_TO_MOVE.items():
+        openupgrade.update_module_moved_fields(
+            cr, model, field_names, PREVIOUS_MODULE_NAME, NEW_MODULE_NAME
+        )
+
+
+def move_records_to_new_module(cr):
+    cr.execute(QUERY_GET_NAMES, (PREVIOUS_MODULE_NAME, MODELS_TO_MOVE))
+    # Result is [(None, )] if empty [([names])] otherwise
+    xmlid_names = [row[0] for row in cr.fetchall()]
+    if not xmlid_names:
+        return
+    xmlids = [
+        (f"{PREVIOUS_MODULE_NAME}.{name}", f"{NEW_MODULE_NAME}.{name}")
+        for name in xmlid_names
+    ]
+    openupgrade.rename_xmlids(cr, xmlids)
+
+
+def backup_adr_code(cr):
+    # Create a new column in which we store the related adr code,
+    # so that we will be able to retrieve the adr.goods record in the
+    # post migration script.
+    cr.execute("ALTER TABLE product_product ADD adr_number varchar;")
+    backup_query = """
+        UPDATE product_product pp
+        SET adr_number = ur.name
+        FROM un_reference ur
+        WHERE ur.id = pp.un_ref
+        AND pp.un_ref IS NOT NULL;
+    """
+    cr.execute(backup_query)
+
+
+def update_transport_category(cr):
+    # In the previous version (13.0) the transport category selection was
+    # [("1", "0"), ("2", "1"), ("3", "2"), ("4", "3"), ("5", "4")]
+    # In the new one, the selection has been updated like so
+    # [
+    #     ("0", "0"),
+    #     ("1", "1"),
+    #     ("2", "2"),
+    #     ("3", "3"),
+    #     ("4", "4"),
+    #     ("-", "-"),
+    #     ("CARRIAGE_PROHIBITED", "CARRIAGE PROHIBITED"),
+    #     ("NOT_SUBJECT_TO_ADR", "Not subject to ADR"),
+    # ]
+    # Updating this now, so we can find the right adr.goods record
+    # in the post script
+    for prev, new in enumerate(range(5), start=1):
+        query = """
+            UPDATE product_product
+            SET transport_category = %(new)s
+            WHERE transport_category = %(prev)s;
+        """
+        cr.execute(query, {"new": str(new), "prev": str(prev)})
+
+
+def migrate(cr, version):
+    update_transport_category(cr)
+    # Move fields and records not present in the new implementation to
+    # `l10n_eu_product_adr_dangerous_good`.
+    move_fields_to_new_module(cr)
+    move_records_to_new_module(cr)
+    # Backup the adr code on product
+    backup_adr_code(cr)

--- a/l10n_eu_product_adr_dangerous_goods/README.rst
+++ b/l10n_eu_product_adr_dangerous_goods/README.rst
@@ -1,0 +1,1 @@
+wait 4 da bot

--- a/l10n_eu_product_adr_dangerous_goods/__init__.py
+++ b/l10n_eu_product_adr_dangerous_goods/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/l10n_eu_product_adr_dangerous_goods/__manifest__.py
+++ b/l10n_eu_product_adr_dangerous_goods/__manifest__.py
@@ -1,0 +1,22 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+{
+    "name": "l10n Eu Product Adr Dangerous Goods",
+    "version": "14.0.1.0.0",
+    "category": "Inventory/Delivery",
+    "website": "https://github.com/OCA/community-data-files",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "maintainers": ["mmequignon"],
+    "license": "AGPL-3",
+    "installable": True,
+    "auto_install": False,
+    "depends": ["l10n_eu_product_adr"],
+    "data": [
+        # data
+        "data/utility_models.xml",
+        # views
+        "views/product_product.xml",
+        # security
+        "security/ir.model.access.csv",
+    ],
+}

--- a/l10n_eu_product_adr_dangerous_goods/data/utility_models.xml
+++ b/l10n_eu_product_adr_dangerous_goods/data/utility_models.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2021 Camptocamp SA
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <!--storage classes-->
+    <record id="storage_class_1" model="storage.class">
+        <field name="name">LK 2</field>
+    </record>
+    <record id="storage_class_2" model="storage.class">
+        <field name="name">LK 3</field>
+    </record>
+    <record id="storage_class_3" model="storage.class">
+        <field name="name">LK 4.1</field>
+    </record>
+    <record id="storage_class_4" model="storage.class">
+        <field name="name">LK 4.2</field>
+    </record>
+    <record id="storage_class_5" model="storage.class">
+        <field name="name">LK 4.3</field>
+    </record>
+    <record id="storage_class_6" model="storage.class">
+        <field name="name">LK 5</field>
+    </record>
+    <record id="storage_class_7" model="storage.class">
+        <field name="name">LK 6.1</field>
+    </record>
+    <record id="storage_class_8" model="storage.class">
+        <field name="name">LK 8</field>
+    </record>
+    <record id="storage_class_9" model="storage.class">
+        <field name="name">LK 10,12</field>
+    </record>
+    <record id="storage_class_10" model="storage.class">
+        <field name="name">LK 11,13</field>
+    </record>
+
+    <!--packaging types-->
+    <record id="packaging_type_1" model="packaging.type">
+        <field name="name">Bottle</field>
+    </record>
+    <record id="packaging_type_2" model="packaging.type">
+        <field name="name">Canister</field>
+    </record>
+    <record id="packaging_type_3" model="packaging.type">
+        <field name="name">Cartridge</field>
+    </record>
+    <record id="packaging_type_4" model="packaging.type">
+        <field name="name">Box</field>
+    </record>
+    <record id="packaging_type_5" model="packaging.type">
+        <field name="name">Bag</field>
+    </record>
+    <record id="packaging_type_6" model="packaging.type">
+        <field name="name">Spray</field>
+    </record>
+    <record id="packaging_type_7" model="packaging.type">
+        <field name="name">Can</field>
+    </record>
+    <record id="packaging_type_8" model="packaging.type">
+        <field name="name">Tube</field>
+    </record>
+
+    <!--storage temps-->
+    <record id="storage_temp_1" model="storage.temp">
+        <field name="name">to 25°C</field>
+    </record>
+    <record id="storage_temp_2" model="storage.temp">
+        <field name="name">over 25°C</field>
+    </record>
+    <record id="storage_temp_3" model="storage.temp">
+        <field name="name">to 30°C</field>
+    </record>
+
+
+    <!--wgk classes-->
+    <record id="wgk_class_1" model="wgk.class">
+        <field name="name">WGK 1</field>
+    </record>
+    <record id="wgk_class_2" model="wgk.class">
+        <field name="name">WGK 2</field>
+    </record>
+    <record id="wgk_class_3" model="wgk.class">
+        <field name="name">WGK 3</field>
+    </record>
+    <record id="wgk_class_4" model="wgk.class">
+        <field name="name">WGK A</field>
+    </record>
+    <record id="wgk_class_5" model="wgk.class">
+        <field name="name">WGK B</field>
+    </record>
+
+    <!--limited amounts-->
+    <record id="limited_amount_1" model="limited.amount">
+        <field name="name">LQ (Limited Quantity)</field>
+    </record>
+    <record id="limited_amount_2" model="limited.amount">
+        <field name="name">DG (Dangerous Goods)</field>
+    </record>
+
+    <!--dangerous uom-->
+    <record id="dangerous_uom_1" model="dangerous.uom">
+        <field name="name">l (Liter)</field>
+    </record>
+    <record id="dangerous_uom_2" model="dangerous.uom">
+        <field name="name">kg (Kilogramm)</field>
+    </record>
+    <record id="dangerous_uom_3" model="dangerous.uom">
+        <field name="name">g (Gramm)</field>
+    </record>
+
+</odoo>

--- a/l10n_eu_product_adr_dangerous_goods/models/__init__.py
+++ b/l10n_eu_product_adr_dangerous_goods/models/__init__.py
@@ -1,0 +1,2 @@
+from . import product_product
+from . import utility_models

--- a/l10n_eu_product_adr_dangerous_goods/models/product_product.py
+++ b/l10n_eu_product_adr_dangerous_goods/models/product_product.py
@@ -1,0 +1,54 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo import fields, models
+
+LABELS_SELECTION = [
+    ("1", "2"),
+    ("2", "2.1"),
+    ("3", "2.2"),
+    ("4", "3"),
+    ("5", "4.1"),
+    ("6", "4.2"),
+    ("7", "4.3"),
+    ("8", "5.1"),
+    ("9", "5.2"),
+    ("10", "8"),
+    ("11", "9"),
+    ("12", "9A"),
+]
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    # To be set manually for the moment. Could eventually be computed after,
+    # depending on the dangerous class and the product's weight/captain'sage…
+    limited_amount_id = fields.Many2one("limited.amount")
+
+    # package-related fields
+    content_package = fields.Float(string="Content Packaging", digits=(16, 5))
+    dg_unit = fields.Many2one("dangerous.uom")
+    nag = fields.Char(string="N.A.G.")
+    veva_code_empty = fields.Char(string="VeVA Code: Empty packaging")
+    veva_code_full = fields.Char(string="VeVA Code: Full package")
+
+    # storage-related fields
+    storage_class_id = fields.Many2one("storage.class")
+    packaging_type_id = fields.Many2one("packaging.type")
+    storage_temp_id = fields.Many2one("storage.temp")
+    flash_point = fields.Char(string="Flash point(°C)")
+    wgk_class_id = fields.Many2one("wgk.class")
+    h_no = fields.Char(string="H-No")  # Ho, NoooOOooooO!
+
+    envir_hazardous = fields.Selection(
+        [("yes", "Yes"), ("no", "No")], string="Environmentally hazardous"
+    )
+    packaging_group = fields.Selection(
+        [("1", "(-)"), ("2", "I"), ("3", "II"), ("4", "III")], string="Packaging Group"
+    )
+    hazard_ind = fields.Char(string="Hazard identification")
+    voc = fields.Char(string="VOC in%")
+    label_first = fields.Selection(LABELS_SELECTION, string="Label 1")
+    label_second = fields.Selection(LABELS_SELECTION, string="Label 2")
+    label_third = fields.Selection(LABELS_SELECTION, string="Label 3")

--- a/l10n_eu_product_adr_dangerous_goods/models/utility_models.py
+++ b/l10n_eu_product_adr_dangerous_goods/models/utility_models.py
@@ -1,0 +1,46 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo import fields, models
+
+
+class StorageClass(models.Model):
+    _name = "storage.class"
+    _description = "Storage class"
+
+    name = fields.Char(string="Name", required=True)
+
+
+class PackagingType(models.Model):
+    _name = "packaging.type"
+    _description = "Packaging"
+
+    name = fields.Char(string="Name", required=True)
+
+
+class StorageTemp(models.Model):
+    _name = "storage.temp"
+    _description = "Storage Temp"
+
+    name = fields.Char(string="Name", required=True, translate=True)
+
+
+class WGKClass(models.Model):
+    _name = "wgk.class"
+    _description = "WGK class"
+
+    name = fields.Char(string="Name", required=True)
+
+
+class LimitedAmount(models.Model):
+    _name = "limited.amount"
+    _description = "Limited Amount"
+
+    name = fields.Char(string="Name", required=True)
+
+
+class DangerousUOM(models.Model):
+    _name = "dangerous.uom"
+    _description = "Dangerous UOM"
+
+    name = fields.Char(string="Name", required=True, translate=True)

--- a/l10n_eu_product_adr_dangerous_goods/readme/CONTRIBUTORS.rst
+++ b/l10n_eu_product_adr_dangerous_goods/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Matthieu Méquignon <matthieu.mequignon@camptocamp.com>

--- a/l10n_eu_product_adr_dangerous_goods/readme/DESCRIPTION.rst
+++ b/l10n_eu_product_adr_dangerous_goods/readme/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+Adds a few utility models and records to the `l10n_eu_product_adr` module.

--- a/l10n_eu_product_adr_dangerous_goods/readme/ROADMAP.rst
+++ b/l10n_eu_product_adr_dangerous_goods/readme/ROADMAP.rst
@@ -1,0 +1,1 @@
+* rename models, prefix them with `adr.` as it is done in `l10n_eu_product_adr`

--- a/l10n_eu_product_adr_dangerous_goods/security/ir.model.access.csv
+++ b/l10n_eu_product_adr_dangerous_goods/security/ir.model.access.csv
@@ -1,0 +1,13 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_storage_class_user,access_storage_class,model_storage_class,base.group_user,1,0,0,0
+access_storage_class_manager,access_storage_class,model_storage_class,base.group_erp_manager,1,1,1,1
+access_packaging_type_user,access_packaging_type,model_packaging_type,base.group_user,1,0,0,0
+access_packaging_type_manager,access_packaging_type,model_packaging_type,base.group_erp_manager,1,1,1,1
+access_storage_temp_user,access_storage_temp,model_storage_temp,base.group_user,1,0,0,0
+access_storage_temp_manager,access_storage_temp,model_storage_temp,base.group_erp_manager,1,1,1,1
+access_wgk_class_user,access_wgk_class,model_wgk_class,base.group_user,1,0,0,0
+access_wgk_class_manager,access_wgk_class,model_wgk_class,base.group_erp_manager,1,1,1,1
+access_limited_amount_user,access_limited_amount,model_limited_amount,base.group_user,1,0,0,0
+access_limited_amount_manager,access_limited_amount,model_limited_amount,base.group_erp_manager,1,1,1,1
+access_dang_uom_user,access_dang_uom_class,model_dangerous_uom,base.group_user,1,0,0,0
+access_dang_uom_manager,access_dang_uom_class_manager,model_dangerous_uom,base.group_erp_manager,1,1,1,1

--- a/l10n_eu_product_adr_dangerous_goods/views/product_product.xml
+++ b/l10n_eu_product_adr_dangerous_goods/views/product_product.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="product_normal_form_view" model="ir.ui.view">
+        <field name="name">product.product.form.inherit</field>
+        <field name="model">product.product</field>
+        <field name="inherit_id" ref="l10n_eu_product_adr.product_normal_form_view" />
+        <field name="arch" type="xml">
+            <xpath expr="//page[@name='adr']/group[last()]" position="after">
+                <group>
+                    <group name="dangerous_packing" string="Dangerous Packaging">
+                        <field name="packaging_group" />
+                        <label for="content_package" />
+                        <div>
+                            <field
+                                name="content_package"
+                                attrs="{'required':[('is_dangerous','=',True)]}"
+                            />
+                            <field
+                                name="dg_unit"
+                                attrs="{'required':[('is_dangerous','=',True)]}"
+                            />
+                        </div>
+                        <field name="label_first" />
+                        <field name="label_second" />
+                        <field name="label_third" />
+                        <field name="flash_point" />
+                    </group>
+                    <group name="storage" string="Storage">
+                        <field name="storage_class_id" />
+                        <field
+                            name="packaging_type_id"
+                            attrs="{'required':[('is_dangerous','=',True)]}"
+                        />
+                        <field name="storage_temp_id" />
+                        <field name="wgk_class_id" />
+                    </group>
+                </group>
+                <group name="hazard_details">
+                    <field name="envir_hazardous" />
+                    <field name="voc" />
+                    <field name="nag" />
+                    <field name="veva_code_empty" />
+                    <field name="veva_code_full" />
+                    <field name="h_no" />
+                    <field name="hazard_ind" />
+                </group>
+            </xpath>
+            <xpath expr="//label[@for='adr_limited_quantity']" position="before">
+                <field name="limited_amount_id" />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/setup/l10n_eu_product_adr_dangerous_goods/odoo/addons/l10n_eu_product_adr_dangerous_goods
+++ b/setup/l10n_eu_product_adr_dangerous_goods/odoo/addons/l10n_eu_product_adr_dangerous_goods
@@ -1,0 +1,1 @@
+../../../../l10n_eu_product_adr_dangerous_goods

--- a/setup/l10n_eu_product_adr_dangerous_goods/setup.py
+++ b/setup/l10n_eu_product_adr_dangerous_goods/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
A few fields and records hasn't been ported to 14.0 during l10n_eu_product_adr migration.
This PR adds a new l10n_eu_product_adr_dangerous_goods module that restores them, and adds a migration script to move them to the new module.

Note, this PR is a merge of those 2 previous ones:
- https://github.com/StefanRijnhart/community-data-files/pull/1
- https://github.com/OCA/community-data-files/pull/118