### PR TITLE
[16.0] base_unece + account_tax_unece: AGPL -> LGPL

### DIFF
--- a/account_tax_unece/__init__.py
+++ b/account_tax_unece/__init__.py
@@ -1,3 +1,1 @@
-# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-
 from . import models

--- a/account_tax_unece/__manifest__.py
+++ b/account_tax_unece/__manifest__.py
@@ -1,12 +1,12 @@
 # Copyright 2016-2020 Akretion France (http://www.akretion.com)
-# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 # @author Alexis de Lattre <alexis.delattre@akretion.com>
 
 {
     "name": "Account Tax UNECE",
     "version": "16.0.1.2.0",
     "category": "Accounting & Finance",
-    "license": "AGPL-3",
+    "license": "LGPL-3",
     "development_status": "Production/Stable",
     "summary": "UNECE nomenclature for taxes",
     "author": "Akretion,Odoo Community Association (OCA)",

--- a/account_tax_unece/models/__init__.py
+++ b/account_tax_unece/models/__init__.py
@@ -1,5 +1,3 @@
-# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-
 from . import unece_code_list
 from . import account_tax
 from . import account_tax_template

--- a/account_tax_unece/models/account_tax.py
+++ b/account_tax_unece/models/account_tax.py
@@ -1,6 +1,6 @@
 # Copyright 2016-2020 Akretion France (http://www.akretion.com)
 # @author: Alexis de Lattre <alexis.delattre@akretion.com>
-# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
 from odoo import api, fields, models
 

--- a/account_tax_unece/models/account_tax_template.py
+++ b/account_tax_unece/models/account_tax_template.py
@@ -1,5 +1,5 @@
 # Copyright 2017-2020 Onestein (<https://www.onestein.eu>)
-# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
 from odoo import fields, models
 

--- a/account_tax_unece/models/res_company.py
+++ b/account_tax_unece/models/res_company.py
@@ -1,6 +1,6 @@
 # Copyright 2020 Akretion France (http://www.akretion.com)
 # @author: Alexis de Lattre <alexis.delattre@akretion.com>
-# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
 from odoo import models
 from odoo.tools import html2plaintext, is_html_empty

--- a/account_tax_unece/models/unece_code_list.py
+++ b/account_tax_unece/models/unece_code_list.py
@@ -1,6 +1,6 @@
 # Copyright 2016-2020 Akretion France (http://www.akretion.com)
 # @author: Alexis de Lattre <alexis.delattre@akretion.com>
-# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
 from odoo import fields, models
 

--- a/account_tax_unece/tests/__init__.py
+++ b/account_tax_unece/tests/__init__.py
@@ -1,3 +1,1 @@
-# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-
 from . import test_tax_unece

--- a/account_tax_unece/tests/test_tax_unece.py
+++ b/account_tax_unece/tests/test_tax_unece.py
@@ -1,6 +1,6 @@
 # Copyright 2017-2020 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
 # Copyright 2019-2020 Onestein (<https://www.onestein.eu>)
-# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
 from odoo.tests.common import HttpCase
 

--- a/account_tax_unece/views/account_tax.xml
+++ b/account_tax_unece/views/account_tax.xml
@@ -2,7 +2,7 @@
 <!--
   Copyright 2016-2020 Akretion (http://www.akretion.com/)
   @author Alexis de Lattre <alexis.delattre@akretion.com>
-  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+  License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 -->
 <odoo>
     <record id="view_tax_form" model="ir.ui.view">

--- a/account_tax_unece/views/account_tax_template.xml
+++ b/account_tax_unece/views/account_tax_template.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- Copyright 2017-2020 Onestein (<http://www.onestein.eu>)
-     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+     License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl). -->
 <odoo>
     <record id="view_tax_template_form" model="ir.ui.view">
         <field name="model">account.tax.template</field>

--- a/base_unece/__init__.py
+++ b/base_unece/__init__.py
@@ -1,3 +1,1 @@
-# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-
 from . import models

--- a/base_unece/__manifest__.py
+++ b/base_unece/__manifest__.py
@@ -1,12 +1,12 @@
 # Copyright 2016-2021 Akretion France (http://www.akretion.com)
-# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 # @author Alexis de Lattre <alexis.delattre@akretion.com>
 
 {
     "name": "Base UNECE",
     "version": "16.0.1.0.0",
     "category": "Tools",
-    "license": "AGPL-3",
+    "license": "LGPL-3",
     "development_status": "Production/Stable",
     "summary": "Base module for UNECE code lists",
     "author": "Akretion,Odoo Community Association (OCA)",

--- a/base_unece/models/__init__.py
+++ b/base_unece/models/__init__.py
@@ -1,3 +1,1 @@
-# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-
 from . import unece_code_list

--- a/base_unece/models/unece_code_list.py
+++ b/base_unece/models/unece_code_list.py
@@ -1,6 +1,6 @@
 # Copyright 2016-2021 Akretion France (http://www.akretion.com)
 # @author: Alexis de Lattre <alexis.delattre@akretion.com>
-# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
 from odoo import api, fields, models
 

--- a/base_unece/views/unece_code_list.xml
+++ b/base_unece/views/unece_code_list.xml
@@ -2,7 +2,7 @@
 <!--
   Copyright 2016-2021 Akretion France (http://www.akretion.com/)
   @author Alexis de Lattre <alexis.delattre@akretion.com>
-  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+  License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 -->
 <odoo>
     <record id="unece_code_list_form" model="ir.ui.view">


### PR DESCRIPTION
If all the contributors on these 2 modules agree, I propose to switch base_unece and account_tax_unece from AGPL to LGPL. This would allow some forks of localization modules, which are LGPL modules, to depend on account_tax_unece to have the fields for the unece codes on tax templates. Example of such a module: l10n_fr_oca https://github.com/OCA/l10n-france/pull/423

I am the initial and main author of those 2 modules. These modules have received contributions from @astirpe @pedrobaeza and @levkar ... are you guys ok with this licence change ?