### PR TITLE
[14.0][FIX][IMP] base_bank_from_iban

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,8 @@
 # Do NOT update manually; changes here will be overwritten by Copier
-_commit: v1.17.2
+_commit: v1.20
 _src_path: gh:oca/oca-addons-repo-template
 ci: GitHub
+convert_readme_fragments_to_markdown: false
 generate_requirements_txt: true
 github_check_license: false
 github_ci_extra_env: {}
@@ -29,4 +30,6 @@ repo_description: 'This project is a collection of Odoo modules containing vario
 repo_name: Community Data Files
 repo_slug: community-data-files
 repo_website: https://github.com/OCA/community-data-files
+use_pyproject_toml: false
+use_ruff: false
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 *.py[cod]
 /.venv
 /.pytest_cache
+/.ruff_cache
 
 # C extensions
 *.so

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,8 @@ exclude: |
   ^docs/_templates/.*\.html$|
   # Don't bother non-technical authors with formatting issues in docs
   readme/.*\.(rst|md)$|
+  # Ignore build and dist directories in addons
+  /build/|/dist/|
   # You don't usually want a bot to modify your legal texts
   (LICENSE.*|COPYING.*)
 default_language_version:
@@ -35,7 +37,7 @@ repos:
         language: fail
         files: '[a-zA-Z0-9_]*/i18n/en\.po$'
   - repo: https://github.com/oca/maintainer-tools
-    rev: 969238e47c07d0c40573acff81d170f63245d738
+    rev: 9a170331575a265c092ee6b24b845ec508e8ef75
     hooks:
       # update the NOT INSTALLABLE ADDONS section above
       - id: oca-update-pre-commit-excluded-addons
@@ -48,13 +50,14 @@ repos:
           - --org-name=OCA
           - --repo-name=community-data-files
           - --if-source-changed
+          - --keep-source-digest
   - repo: https://github.com/OCA/odoo-pre-commit-hooks
     rev: v0.0.25
     hooks:
       - id: oca-checks-odoo-module
       - id: oca-checks-po
   - repo: https://github.com/myint/autoflake
-    rev: v1.4
+    rev: v1.5.3
     hooks:
       - id: autoflake
         args:
@@ -133,7 +136,7 @@ repos:
           - --header
           - "# generated from manifests external_dependencies"
   - repo: https://github.com/PyCQA/flake8
-    rev: 3.8.3
+    rev: 5.0.0
     hooks:
       - id: flake8
         name: flake8

--- a/base_bank_from_iban/models/res_partner_bank.py
+++ b/base_bank_from_iban/models/res_partner_bank.py
@@ -24,7 +24,13 @@ class ResPartnerBank(models.Model):
         last_match = iban_template.rfind("B") + 1
         bank_code = acc_number[first_match:last_match].replace(" ", "")
         bank = self.env["res.bank"].search(
-            [("code", "=", bank_code), ("country.code", "=", country_code.upper())],
+            [
+                "&",
+                ("country.code", "=", country_code.upper()),
+                "|",
+                ("code", "=", bank_code),
+                ("bic", "like", bank_code),
+            ],
             limit=1,
         )
         self.update({"bank_id": bank.id, "acc_number": acc_number})


### PR DESCRIPTION
Fixes issue #129

Before this PR the module worked counter intuitive.
It relies on the field `code` which is introduced by the module itself.

Since it is not a native odoo field. It is not populated with data from one of the bank list modules:
e.g. https://github.com/OCA/l10n-croatia/tree/16.0/l10n_hr_bank
https://github.com/OCA/l10n-netherlands/tree/14.0/l10n_nl_bank

An option was to populate that field. But then all these localization modules needed to be adjusted.
AFAIK the field `code` has no real use case, then just to search. 
As opposed to a BIC field. Which could be used in payment (xml) files. 
And should be  visible on invoices. Source: https://www.ecbs.org/iban.htm

This adds support to match a bank based upon the BIC code which is encapsulated inside the IBAN.
Which is used by iban's from the following countries:
UK, Netherlands, Bulgaria, Malta, Latvia, Romania, Gibraltar

https://en.wikipedia.org/wiki/International_Bank_Account_Number#IBAN_formats_by_country

