### PR TITLE
[IMP] uom_unece: Change unit code from C62 to PCE

### DIFF
--- a/uom_unece/data/unece.xml
+++ b/uom_unece/data/unece.xml
@@ -2,7 +2,7 @@
 <odoo>
     <!-- Units -->
     <record id="uom.product_uom_unit" model="uom.uom">
-        <field name="unece_code">C62</field>
+        <field name="unece_code">PCE</field>
     </record>
     <record id="uom.product_uom_dozen" model="uom.uom">
         <field name="unece_code">DPC</field>


### PR DESCRIPTION
According to https://www.gs1us.org/resources/data-hub-help-center/unit-of-measure-codes **C62** means _one_ while **PCE** means _piece_. I think **PCE** is correct as for example _dozen_ is encoded as **DPC** meaning _dozen piece_.