### PR TITLE
[15.0][FIX] base_bank_from_iban: Handle correctly non IBAN accounts

### DIFF
--- a/base_bank_from_iban/tests/test_base_bank_from_iban.py
+++ b/base_bank_from_iban/tests/test_base_bank_from_iban.py
@@ -1,5 +1,5 @@
-# Copyright 2017 Tecnativa - Carlos Dauden <carlos.dauden@tecnativa.com>
-# Copyright 2022 Tecnativa - Pedro M. Baeza
+# Copyright 2017 Tecnativa - Carlos Dauden
+# Copyright 2022,2024 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl-3).
 
 from odoo.tests import Form, common
@@ -56,3 +56,40 @@ class TestBaseBankFromIban(common.TransactionCase):
         self.assertEqual(wizard.bank_id, self.bank)
         wizard.acc_number = ""
         self.assertEqual(wizard.bank_id, self.bank)
+
+    def test_create_iban_not_found(self):
+        partner_bank = self.env["res.partner.bank"].create(
+            {"acc_number": "es1299999999509999999999", "partner_id": self.partner.id}
+        )
+        self.assertFalse(partner_bank.bank_id)
+
+    def test_create_iban_found(self):
+        partner_bank = self.env["res.partner.bank"].create(
+            {"acc_number": "DE89370400440532013000", "partner_id": self.partner.id}
+        )
+        self.assertTrue(partner_bank.bank_id)
+        self.assertTrue(partner_bank.bank_id.name, "Commerzbank")
+        self.assertTrue(partner_bank.bank_id.bic, "COBADEFFXXX")
+        self.assertTrue(partner_bank.bank_id.code, "37040044")
+        self.assertTrue(partner_bank.bank_id.country.code, "DE")
+
+    def test_create_iban_found_existing_bank(self):
+        bank = self.env["res.bank"].create(
+            {
+                "country": self.env.ref("base.de").id,
+                "code": "37040044",
+                "name": "Commerzbank",
+            }
+        )
+        partner_bank = self.env["res.partner.bank"].create(
+            {"acc_number": "DE89370400440532013000", "partner_id": self.partner.id}
+        )
+        self.assertEqual(partner_bank.bank_id, bank)
+        self.assertTrue(bank.bic, "COBADEFFXXX")
+
+    def test_create_invalid_iban(self):
+        partner_bank = self.env["res.partner.bank"].create(
+            {"acc_number": "1234567890", "partner_id": self.partner.id}
+        )
+        # The important thing here is to not see any warning in the log
+        self.assertTrue(partner_bank)


### PR DESCRIPTION
Backport of #206 

If any non IBAN account is provided, there's an ugly log with traceback each time, polluting tests and system logs:

```
INFO prod odoo.addons.base_bank_from_iban.models.res_partner_bank: Could not find bank from IBAN
Traceback (most recent call last):
  File ".../addons/base_bank_from_iban/models/res_partner_bank.py", line 34, in _add_bank_vals
    bank = self._get_bank_from_iban(vals["acc_number"])
  File ".../addons/base_bank_from_iban/models/res_partner_bank.py", line 42, in _get_bank_from_iban
    iban = schwifty.IBAN(acc_number)
  File ".../python/site-packages/schwifty/iban.py", line 77, in __init__
    self.validate(validate_bban)
  File ".../python/site-packages/schwifty/iban.py", line 175, in validate
    self._validate_characters()
  File ".../python/site-packages/schwifty/iban.py", line 185, in _validate_characters
    raise exceptions.InvalidStructure(f"Invalid characters in IBAN {self!s}")
schwifty.exceptions.InvalidStructure: Invalid characters in IBAN XXXXXX
```

This commit removes that traceback catching the proper exception, and handling it accordingly, and also removing an extra INFO log that was not adding value.

@Tecnativa