### PR TITLE
[FIX][18.0] l10n_eu_product_adr: Fixed the kanban image in the adr label level.

### DIFF
--- a/l10n_eu_product_adr/views/adr_label_views.xml
+++ b/l10n_eu_product_adr/views/adr_label_views.xml
@@ -25,10 +25,13 @@
                             t-attf-class="oe_kanban_global_click"
                             style="min-width:450px;min-height:80px"
                         >
-                            <div class="o_kanban_image">
-                                <img
-                                    alt="Label image"
-                                    t-att-src="kanban_image('adr.label', 'image', record.id.raw_value)"
+                            <div class="o_kanban_image_fill position-relative w-100">
+                                <field
+                                    name="image"
+                                    t-if="record.image"
+                                    class="o_image_64_contain mw-100"
+                                    widget="image"
+                                    options="{'preview_image': 'image', 'img_class': 'object-fit-contain'}"
                                 />
                             </div>
                             <div class="oe_kanban_details">


### PR DESCRIPTION
Reason: There is an error when opening or clicking the tab "Dangerous Goods" in the product form view or similar views where Kaban view of the "adr.label" model has been added.

![kanban-img-issue](https://github.com/user-attachments/assets/57e04c90-a426-46b2-8f4b-93f12239592b)
