### PR TITLE
[16.0][FIX] base_bank_from_iban: Don't fail on missing country

### DIFF
--- a/base_bank_from_iban/models/res_partner_bank.py
+++ b/base_bank_from_iban/models/res_partner_bank.py
@@ -34,8 +34,8 @@ class ResPartnerBank(models.Model):
     def _get_bank_from_iban(self, acc_number):
         try:
             iban = schwifty.IBAN(acc_number)
-            country_code = iban.country_code.lower()
-            country = self.env.ref("base.%s" % country_code, raise_if_not_found=False)
+            country_code = iban.country_code
+            country = self.env["res.country"].search([("code", "=", country_code)])
             if iban.bank:
                 vals = {
                     "name": iban.bank["name"],


### PR DESCRIPTION
Previous code using the XML-IDs has 2 problems:

- If not found, it returns False instead of an empty recordset, giving error later on the code when accessing `country.id`.
- The XML-IDs are not the same as the country codes. Example, United Kingdom is `base.uk`, not `base.gb`.

Then, let's search the country by code directly for tackling both problems.

@Tecnativa 