### PR TITLE
[15.0][FIX] base_iso3166: Don't declare types for inherited views

### DIFF
--- a/base_iso3166/views/country_view.xml
+++ b/base_iso3166/views/country_view.xml
@@ -4,7 +4,6 @@
         <field name="name">Country form (with ISO 3166-1 alpha-3)</field>
         <field name="model">res.country</field>
         <field name="inherit_id" ref="base.view_country_form" />
-        <field name="type">form</field>
         <field name="arch" type="xml">
             <field name="code" position="after">
                 <field name="code_alpha3" />
@@ -16,7 +15,6 @@
         <field name="name">Country tree (with ISO 3166-1 alpha-3)</field>
         <field name="model">res.country</field>
         <field name="inherit_id" ref="base.view_country_tree" />
-        <field name="type">form</field>
         <field name="arch" type="xml">
             <field name="code" position="after">
                 <field name="code_alpha3" />


### PR DESCRIPTION
One of them (view_country_tree) is incorrect, and it will arise in later versions, but they are not needed, as they are infered from its parent view.

@Tecnativa 