### PR TITLE
[FIX][18.0] l10n_eu_nace: Ensure en_US is the only language active

### DIFF
--- a/l10n_eu_nace/tests/test_res_partner_industry_eu_nace_wizard.py
+++ b/l10n_eu_nace/tests/test_res_partner_industry_eu_nace_wizard.py
@@ -43,6 +43,8 @@ class TestResPartnerIndustryEUNaceWizard(TransactionCase):
         return import_wizard
 
     def test_get_languages(self):
+        active_languages = ["base.lang_en"]
+        self.activate_langs(active_languages)
         nace_wizard = self.wizard_eu_nace()
         self.assertEqual(nace_wizard.get_languages(), [("en_US", "EN")])
 


### PR DESCRIPTION
Ensure en_US is the only language active by default.

MT-12142 @moduon @yajo 