### PR TITLE
[16.0][FIX] base_bank_from_iban: Add new except to _get_bank_from_iban

### DIFF
--- a/base_bank_from_iban/models/res_partner_bank.py
+++ b/base_bank_from_iban/models/res_partner_bank.py
@@ -56,7 +56,10 @@ class ResPartnerBank(models.Model):
                     bank = self.env["res.bank"].create(vals)
             else:
                 bank = self.env["res.bank"]
-        except schwifty.exceptions.InvalidStructure:
+        except (
+            schwifty.exceptions.InvalidStructure,
+            schwifty.exceptions.InvalidChecksumDigits,
+        ):
             bank = self.env["res.bank"]
         return bank
 


### PR DESCRIPTION
To avoid errors, we must add exceptions to the `_get_bank_from_iban` method of the `res.partner.bank` model.
```
File "/opt/odoo/auto/addons/account_payment_partner/tests/test_account_payment_partner.py", line 523, in test_refund_no_payment_mode_preserves_partner_bank
    trusted_bank = self.env["res.partner.bank"].create(
  File "<decorator-gen-782>", line 2, in create
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 430, in _model_create_multi
    return create(self, [arg])
  File "/opt/odoo/auto/addons/base_bank_from_iban/models/res_partner_bank.py", line 21, in create
    vals_list = [self._add_bank_vals(vals) for vals in vals_list]
  File "/opt/odoo/auto/addons/base_bank_from_iban/models/res_partner_bank.py", line 21, in <listcomp>
    vals_list = [self._add_bank_vals(vals) for vals in vals_list]
  File "/opt/odoo/auto/addons/base_bank_from_iban/models/res_partner_bank.py", line 30, in _add_bank_vals
    vals["bank_id"] = self._get_bank_from_iban(vals["acc_number"]).id
  File "/opt/odoo/auto/addons/base_bank_from_iban/models/res_partner_bank.py", line 36, in _get_bank_from_iban
    iban = schwifty.IBAN(acc_number)
  File "/usr/local/lib/python3.10/site-packages/schwifty/iban.py", line 77, in __init__
    self.validate(validate_bban)
  File "/usr/local/lib/python3.10/site-packages/schwifty/iban.py", line 178, in validate
    self._validate_iban_checksum()
  File "/usr/local/lib/python3.10/site-packages/schwifty/iban.py", line 202, in _validate_iban_checksum
    raise exceptions.InvalidChecksumDigits("Invalid checksum digits")
schwifty.exceptions.InvalidChecksumDigits: Invalid checksum digits
```
@pedrobaeza can you review?
@Tecnativa