### PR TITLE
[18.0][FIX] base_bank_from_iban: Broader except for _get_bank_from_iban

### DIFF
--- a/base_bank_from_iban/models/res_partner_bank.py
+++ b/base_bank_from_iban/models/res_partner_bank.py
@@ -56,10 +56,7 @@ class ResPartnerBank(models.Model):
                     bank = self.env["res.bank"].create(vals)
             else:
                 bank = self.env["res.bank"]
-        except (
-            schwifty.exceptions.InvalidStructure,
-            schwifty.exceptions.InvalidChecksumDigits,
-        ):
+        except schwifty.exceptions.SchwiftyException:
             bank = self.env["res.bank"]
         return bank
 


### PR DESCRIPTION
Our goal is to provide a fall back for any wrongly formatted iban.
Instead of catching every possible formatting issue one by one, let's catch their parent exception class.

I stumbled onto this issue because Odoo is using 17 characters long french iban in unit tests, while french iban are 27 characters long.
Hence, I have noticed that `schwifty.exceptions.InvalidLength` is missing from the list of expected schwifty errors, like others.